### PR TITLE
fix(Interactions): fix spelling error on InteractableFacade editor - fixes #11

### DIFF
--- a/Editor/Interactables/InteractableFacadeEditor.cs
+++ b/Editor/Interactables/InteractableFacadeEditor.cs
@@ -140,7 +140,7 @@
                 EditorGUILayout.EndHorizontal();
             }
 
-            showFollowAdvancedFeatures = EditorGUILayout.Foldout(showFollowAdvancedFeatures, "Advanced Follow Serttings");
+            showFollowAdvancedFeatures = EditorGUILayout.Foldout(showFollowAdvancedFeatures, "Advanced Follow Settings");
             if (showFollowAdvancedFeatures)
             {
                 EditorGUI.indentLevel++;


### PR DESCRIPTION
There was a small spelling error on the custom InteractableFacade
editor, which has now been corrected.