### PR TITLE
feat(Interactables): apply more specific namespace to interactables

### DIFF
--- a/Editor/Interactables/InteractableCreatorEditorWindow.cs
+++ b/Editor/Interactables/InteractableCreatorEditorWindow.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables
+﻿namespace Tilia.Interactions.Interactables.Interactables
 {
     using UnityEditor;
     using UnityEngine;

--- a/Editor/Interactables/InteractableFacadeEditor.cs
+++ b/Editor/Interactables/InteractableFacadeEditor.cs
@@ -1,8 +1,8 @@
-﻿namespace Tilia.Interactions.Interactables
+﻿namespace Tilia.Interactions.Interactables.Interactables
 {
     using Malimbe.FodyRunner.UnityIntegration;
     using System;
-    using Tilia.Interactions.Interactables.Grab.Action;
+    using Tilia.Interactions.Interactables.Interactables.Grab.Action;
     using UnityEditor;
     using UnityEditor.SceneManagement;
     using UnityEngine;

--- a/Runtime/Interactables/SharedResources/Scripts/Event/Proxy/InteractableFacadeEventProxyEmitter.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Event/Proxy/InteractableFacadeEventProxyEmitter.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Event.Proxy
+﻿namespace Tilia.Interactions.Interactables.Interactables.Event.Proxy
 {
     using System;
     using UnityEngine.Events;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableAction.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Action
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Action
 {
     using Malimbe.MemberChangeMethod;
     using Malimbe.PropertySerializationAttribute;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableControlDirectionAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableControlDirectionAction.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Action
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Action
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Action
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Action
 {
     using Malimbe.MemberChangeMethod;
     using Malimbe.PropertySerializationAttribute;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableScaleAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableScaleAction.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Action
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Action
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableSwapAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableSwapAction.cs
@@ -1,6 +1,6 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Action
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Action
 {
-    using Tilia.Interactions.Interactables.Grab.Provider;
+    using Tilia.Interactions.Interactables.Interactables.Grab.Provider;
     using UnityEngine;
 
     /// <summary>

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
@@ -1,13 +1,13 @@
-﻿namespace Tilia.Interactions.Interactables.Grab
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab
 {
     using Malimbe.MemberChangeMethod;
     using Malimbe.MemberClearanceMethod;
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
     using System.Collections.Generic;
-    using Tilia.Interactions.Interactables.Grab.Action;
-    using Tilia.Interactions.Interactables.Grab.Provider;
-    using Tilia.Interactions.Interactables.Grab.Receiver;
+    using Tilia.Interactions.Interactables.Interactables.Grab.Action;
+    using Tilia.Interactions.Interactables.Interactables.Grab.Provider;
+    using Tilia.Interactions.Interactables.Interactables.Grab.Receiver;
     using Tilia.Interactions.Interactables.Interactors;
     using UnityEngine;
     using Zinnia.Data.Attribute;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabStateEmitter.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabStateEmitter.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab
 {
     using UnityEngine;
     using UnityEngine.Events;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabStateRegistrar.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabStateRegistrar.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab
 {
     using UnityEngine;
     using UnityEngine.Events;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Provider/GrabInteractableInteractorProvider.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Provider/GrabInteractableInteractorProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Provider
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Provider
 {
     using UnityEngine;
     using System.Collections.Generic;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Provider/GrabInteractableListInteractorProvider.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Provider/GrabInteractableListInteractorProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Provider
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Provider
 {
     using UnityEngine;
     using System.Collections.Generic;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Provider/GrabInteractableStackInteractorProvider.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Provider/GrabInteractableStackInteractorProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Provider
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Provider
 {
     using UnityEngine;
     using System.Collections.Generic;

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Receiver/GrabInteractableReceiver.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Receiver/GrabInteractableReceiver.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Grab.Receiver
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Receiver
 {
     using UnityEngine;
     using Malimbe.MemberChangeMethod;

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableActionReceiverConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableActionReceiverConfigurator.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables
+﻿namespace Tilia.Interactions.Interactables.Interactables
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableActionReceiverFacade.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableActionReceiverFacade.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables
+﻿namespace Tilia.Interactions.Interactables.Interactables
 {
     using Malimbe.MemberChangeMethod;
     using Malimbe.MemberClearanceMethod;

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
@@ -1,17 +1,20 @@
-﻿namespace Tilia.Interactions.Interactables
+﻿namespace Tilia.Interactions.Interactables.Interactables
 {
     using Malimbe.MemberChangeMethod;
     using Malimbe.MemberClearanceMethod;
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
-    using Tilia.Interactions.Interactables.Grab;
-    using Tilia.Interactions.Interactables.Touch;
+    using Tilia.Interactions.Interactables.Interactables.Grab;
+    using Tilia.Interactions.Interactables.Interactables.Touch;
     using UnityEngine;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Collection.List;
     using Zinnia.Rule;
     using Zinnia.Tracking.Collision;
 
+    /// <summary>
+    /// Sets up the Interactable Prefab based on the provided user settings.
+    /// </summary>
     public class InteractableConfigurator : MonoBehaviour
     {
         #region Facade Settings

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
@@ -1,11 +1,11 @@
-﻿namespace Tilia.Interactions.Interactables
+﻿namespace Tilia.Interactions.Interactables.Interactables
 {
     using Malimbe.MemberChangeMethod;
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
     using System;
     using System.Collections.Generic;
-    using Tilia.Interactions.Interactables.Grab.Receiver;
+    using Tilia.Interactions.Interactables.Interactables.Grab.Receiver;
     using Tilia.Interactions.Interactables.Interactors;
     using UnityEngine;
     using UnityEngine.Events;

--- a/Runtime/Interactables/SharedResources/Scripts/InteractablePropertyCache.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractablePropertyCache.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables
+﻿namespace Tilia.Interactions.Interactables.Interactables
 {
     using Malimbe.BehaviourStateRequirementMethod;
     using Malimbe.MemberClearanceMethod;

--- a/Runtime/Interactables/SharedResources/Scripts/Operation/Extraction/InteractableConsumerContainerExtractor.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Operation/Extraction/InteractableConsumerContainerExtractor.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Operation.Extraction
+﻿namespace Tilia.Interactions.Interactables.Interactables.Operation.Extraction
 {
     using UnityEngine;
     using Zinnia.Data.Operation.Extraction;

--- a/Runtime/Interactables/SharedResources/Scripts/Operation/Extraction/InteractableConsumerRigidbodyExtractor.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Operation/Extraction/InteractableConsumerRigidbodyExtractor.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Operation.Extraction
+﻿namespace Tilia.Interactions.Interactables.Interactables.Operation.Extraction
 {
     using UnityEngine;
     using Zinnia.Data.Operation.Extraction;

--- a/Runtime/Interactables/SharedResources/Scripts/Operation/Extraction/InteractableFacadeExtractor.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Operation/Extraction/InteractableFacadeExtractor.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Operation.Extraction
+﻿namespace Tilia.Interactions.Interactables.Interactables.Operation.Extraction
 {
     using System;
     using UnityEngine.Events;

--- a/Runtime/Interactables/SharedResources/Scripts/Touch/TouchInteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Touch/TouchInteractableConfigurator.cs
@@ -1,4 +1,4 @@
-﻿namespace Tilia.Interactions.Interactables.Touch
+﻿namespace Tilia.Interactions.Interactables.Interactables.Touch
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;

--- a/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
@@ -5,6 +5,7 @@
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
     using System.Collections.Generic;
+    using Tilia.Interactions.Interactables.Interactables;
     using UnityEngine;
     using Zinnia.Action;
     using Zinnia.Data.Attribute;

--- a/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
@@ -6,6 +6,7 @@
     using Malimbe.XmlDocumentationAttribute;
     using System;
     using System.Collections.Generic;
+    using Tilia.Interactions.Interactables.Interactables;
     using UnityEngine;
     using UnityEngine.Events;
     using Zinnia.Action;


### PR DESCRIPTION
Previously, the Interactables were in a namespace that was at a higher
level of the Interactors whereas Interactables should be at the same
level.

There is already an Interactables namespace used by both interactors
and interactables so the best solution is to just have a double
Interactables.Interactables namespace. Whilst this looks a bit strange
it at least buckets the code at the correct level.