### PR TITLE
feat(Interactables): provide helper methods for common tasks

### DIFF
--- a/Documentation/API/Interactables/InteractableFacade.md
+++ b/Documentation/API/Interactables/InteractableFacade.md
@@ -20,19 +20,35 @@ The public interface into the Interactable Prefab.
   * [ungrabRoutine]
   * [Untouched]
 * [Properties]
+  * [Colliders]
   * [Configuration]
   * [GrabbingInteractors]
+  * [GrabEnabled]
   * [GrabProviderIndex]
   * [GrabType]
+  * [InteractableRigidbody]
   * [IsGrabbed]
   * [IsGrabTypeToggle]
   * [IsTouched]
+  * [MeshContainer]
+  * [Meshes]
+  * [PrimaryGrabEnabled]
+  * [SecondaryGrabEnabled]
+  * [TouchEnabled]
   * [TouchingInteractors]
 * [Methods]
+  * [DisableGrab()]
+  * [DisablePrimaryGrabAction()]
+  * [DisableSecondaryGrabAction()]
+  * [DisableTouch()]
   * [DoGrabAtEndOfFrame(InteractorFacade)]
   * [DoGrabIgnoreUngrabAtEndOfFrame(InteractorFacade)]
   * [DoUngrabAtEndOfFrame(Int32)]
   * [DoUngrabAtEndOfFrame(InteractorFacade)]
+  * [EnableGrab()]
+  * [EnablePrimaryGrabAction()]
+  * [EnableSecondaryGrabAction()]
+  * [EnableTouch()]
   * [GetInteractorFromGameObject(GameObject)]
   * [Grab(GameObject)]
   * [Grab(InteractorFacade)]
@@ -182,6 +198,16 @@ public InteractableFacade.UnityEvent Untouched
 
 ### Properties
 
+#### Colliders
+
+Returns a Collider collection of all the [MeshContainer] child colliders.
+
+##### Declaration
+
+```
+public Collider[] Colliders { get; }
+```
+
 #### Configuration
 
 The linked [InteractableConfigurator].
@@ -202,6 +228,16 @@ A collection of Interactors that are currently grabbing the Interactable.
 public IReadOnlyList<InteractorFacade> GrabbingInteractors { get; }
 ```
 
+#### GrabEnabled
+
+Whether the grab functionality is enabled.
+
+##### Declaration
+
+```
+public bool GrabEnabled { get; }
+```
+
 #### GrabProviderIndex
 
 The GrabInteractableInteractorProvider to use.
@@ -220,6 +256,16 @@ The linked [GrabInteractableReceiver.ActiveType].
 
 ```
 public GrabInteractableReceiver.ActiveType GrabType { get; set; }
+```
+
+#### InteractableRigidbody
+
+The Rigidbody attached to the Interactable.
+
+##### Declaration
+
+```
+public Rigidbody InteractableRigidbody { get; }
 ```
 
 #### IsGrabbed
@@ -252,6 +298,56 @@ Whether the Interactable is currently being touched by any valid Interactor.
 public bool IsTouched { get; }
 ```
 
+#### MeshContainer
+
+The mesh container.
+
+##### Declaration
+
+```
+public GameObject MeshContainer { get; }
+```
+
+#### Meshes
+
+Returns a MeshRenderer collection of all the [MeshContainer] child meshes.
+
+##### Declaration
+
+```
+public MeshRenderer[] Meshes { get; }
+```
+
+#### PrimaryGrabEnabled
+
+Whether the primary grab action functionality is enabled.
+
+##### Declaration
+
+```
+public bool PrimaryGrabEnabled { get; }
+```
+
+#### SecondaryGrabEnabled
+
+Whether the secondary grab action functionality is enabled.
+
+##### Declaration
+
+```
+public bool SecondaryGrabEnabled { get; }
+```
+
+#### TouchEnabled
+
+Whether the touch functionality is enabled.
+
+##### Declaration
+
+```
+public bool TouchEnabled { get; }
+```
+
 #### TouchingInteractors
 
 A collection of Interactors that are currently touching the Interactable.
@@ -263,6 +359,46 @@ public IReadOnlyList<InteractorFacade> TouchingInteractors { get; }
 ```
 
 ### Methods
+
+#### DisableGrab()
+
+Disables the grab logic.
+
+##### Declaration
+
+```
+public virtual void DisableGrab()
+```
+
+#### DisablePrimaryGrabAction()
+
+Disables the primary grab action logic.
+
+##### Declaration
+
+```
+public virtual void DisablePrimaryGrabAction()
+```
+
+#### DisableSecondaryGrabAction()
+
+Disables the secondary grab action logic.
+
+##### Declaration
+
+```
+public virtual void DisableSecondaryGrabAction()
+```
+
+#### DisableTouch()
+
+Disables the touch logic.
+
+##### Declaration
+
+```
+public virtual void DisableTouch()
+```
 
 #### DoGrabAtEndOfFrame(InteractorFacade)
 
@@ -351,6 +487,46 @@ protected virtual IEnumerator DoUngrabAtEndOfFrame(InteractorFacade interactor)
 | Type | Description |
 | --- | --- |
 | System.Collections.IEnumerator | An Enumerator to manage the running of the Coroutine. |
+
+#### EnableGrab()
+
+Enables the grab logic.
+
+##### Declaration
+
+```
+public virtual void EnableGrab()
+```
+
+#### EnablePrimaryGrabAction()
+
+Enables the primary grab action logic.
+
+##### Declaration
+
+```
+public virtual void EnablePrimaryGrabAction()
+```
+
+#### EnableSecondaryGrabAction()
+
+Enables the secondary grab action logic.
+
+##### Declaration
+
+```
+public virtual void EnableSecondaryGrabAction()
+```
+
+#### EnableTouch()
+
+Enables the touch logic.
+
+##### Declaration
+
+```
+public virtual void EnableTouch()
+```
 
 #### GetInteractorFromGameObject(GameObject)
 
@@ -620,9 +796,11 @@ public virtual void UngrabAtEndOfFrame(InteractorFacade interactor)
 
 [Tilia.Interactions.Interactables.Interactables]: README.md
 [InteractableFacade.UnityEvent]: InteractableFacade.UnityEvent.md
+[MeshContainer]: InteractableFacade.md#MeshContainer
 [InteractableConfigurator]: InteractableConfigurator.md
 [InteractorFacade]: ../Interactors/InteractorFacade.md
 [GrabInteractableReceiver.ActiveType]: Grab/Receiver/GrabInteractableReceiver.ActiveType.md
+[MeshContainer]: InteractableFacade.md#MeshContainer
 [GrabProviderIndex]: InteractableFacade.md#GrabProviderIndex
 [GrabType]: InteractableFacade.md#GrabType
 [Inheritance]: #Inheritance
@@ -641,19 +819,35 @@ public virtual void UngrabAtEndOfFrame(InteractorFacade interactor)
 [ungrabRoutine]: #ungrabRoutine
 [Untouched]: #Untouched
 [Properties]: #Properties
+[Colliders]: #Colliders
 [Configuration]: #Configuration
 [GrabbingInteractors]: #GrabbingInteractors
+[GrabEnabled]: #GrabEnabled
 [GrabProviderIndex]: #GrabProviderIndex
 [GrabType]: #GrabType
+[InteractableRigidbody]: #InteractableRigidbody
 [IsGrabbed]: #IsGrabbed
 [IsGrabTypeToggle]: #IsGrabTypeToggle
 [IsTouched]: #IsTouched
+[MeshContainer]: #MeshContainer
+[Meshes]: #Meshes
+[PrimaryGrabEnabled]: #PrimaryGrabEnabled
+[SecondaryGrabEnabled]: #SecondaryGrabEnabled
+[TouchEnabled]: #TouchEnabled
 [TouchingInteractors]: #TouchingInteractors
 [Methods]: #Methods
+[DisableGrab()]: #DisableGrab
+[DisablePrimaryGrabAction()]: #DisablePrimaryGrabAction
+[DisableSecondaryGrabAction()]: #DisableSecondaryGrabAction
+[DisableTouch()]: #DisableTouch
 [DoGrabAtEndOfFrame(InteractorFacade)]: #DoGrabAtEndOfFrameInteractorFacade
 [DoGrabIgnoreUngrabAtEndOfFrame(InteractorFacade)]: #DoGrabIgnoreUngrabAtEndOfFrameInteractorFacade
 [DoUngrabAtEndOfFrame(Int32)]: #DoUngrabAtEndOfFrameInt32
 [DoUngrabAtEndOfFrame(InteractorFacade)]: #DoUngrabAtEndOfFrameInteractorFacade
+[EnableGrab()]: #EnableGrab
+[EnablePrimaryGrabAction()]: #EnablePrimaryGrabAction
+[EnableSecondaryGrabAction()]: #EnableSecondaryGrabAction
+[EnableTouch()]: #EnableTouch
 [GetInteractorFromGameObject(GameObject)]: #GetInteractorFromGameObjectGameObject
 [Grab(GameObject)]: #GrabGameObject
 [Grab(InteractorFacade)]: #GrabInteractorFacade

--- a/Documentation/API/Interactables/Touch/TouchInteractableConfigurator.md
+++ b/Documentation/API/Interactables/Touch/TouchInteractableConfigurator.md
@@ -8,8 +8,11 @@
 * [Fields]
   * [touchingInteractors]
 * [Properties]
+  * [ActiveInteractorCounter]
   * [AddActiveInteractor]
   * [CurrentTouchingObjects]
+  * [CurrentUntouchingEventProxy]
+  * [CurrentUntouchingObjects]
   * [Facade]
   * [PotentialInteractors]
   * [RemoveActiveInteractor]
@@ -27,6 +30,7 @@
   * [OnEnable()]
   * [ProcessPotentialInteractorContentChange(CollisionNotifier.EventData)]
   * [UnlinkActiveInteractorCollisions()]
+  * [UntouchAllTouchingInteractors()]
 
 ## Details
 
@@ -59,6 +63,16 @@ protected readonly List<InteractorFacade> touchingInteractors
 
 ### Properties
 
+#### ActiveInteractorCounter
+
+The GameObjectObservableCounter for counting active interactors.
+
+##### Declaration
+
+```
+public GameObjectObservableCounter ActiveInteractorCounter { get; protected set; }
+```
+
 #### AddActiveInteractor
 
 The NotifierContainerExtractor for adding active interactors.
@@ -77,6 +91,26 @@ The GameObjectObservableList that holds the current touching objects data.
 
 ```
 public GameObjectObservableList CurrentTouchingObjects { get; protected set; }
+```
+
+#### CurrentUntouchingEventProxy
+
+The GameObjectEventProxyEmitter used to determine the untouch actions.
+
+##### Declaration
+
+```
+public GameObjectEventProxyEmitter CurrentUntouchingEventProxy { get; protected set; }
+```
+
+#### CurrentUntouchingObjects
+
+The GameObjectObservableList that holds the current untouching objects data.
+
+##### Declaration
+
+```
+public GameObjectObservableList CurrentUntouchingObjects { get; protected set; }
 ```
 
 #### Facade
@@ -261,6 +295,16 @@ Unlinks the CollisionNotifier to the potential and active interactor logic.
 protected virtual void UnlinkActiveInteractorCollisions()
 ```
 
+#### UntouchAllTouchingInteractors()
+
+Enforces that all the existing touching interactors are no longer actually touching.
+
+##### Declaration
+
+```
+public virtual void UntouchAllTouchingInteractors()
+```
+
 [Tilia.Interactions.Interactables.Interactables.Touch]: README.md
 [InteractorFacade]: ../../Interactors/InteractorFacade.md
 [InteractableFacade]: ../../Interactables/InteractableFacade.md
@@ -270,8 +314,11 @@ protected virtual void UnlinkActiveInteractorCollisions()
 [Fields]: #Fields
 [touchingInteractors]: #touchingInteractors
 [Properties]: #Properties
+[ActiveInteractorCounter]: #ActiveInteractorCounter
 [AddActiveInteractor]: #AddActiveInteractor
 [CurrentTouchingObjects]: #CurrentTouchingObjects
+[CurrentUntouchingEventProxy]: #CurrentUntouchingEventProxy
+[CurrentUntouchingObjects]: #CurrentUntouchingObjects
 [Facade]: #Facade
 [PotentialInteractors]: #PotentialInteractors
 [RemoveActiveInteractor]: #RemoveActiveInteractor
@@ -289,3 +336,4 @@ protected virtual void UnlinkActiveInteractorCollisions()
 [OnEnable()]: #OnEnable
 [ProcessPotentialInteractorContentChange(CollisionNotifier.EventData)]: #ProcessPotentialInteractorContentChangeCollisionNotifier.EventData
 [UnlinkActiveInteractorCollisions()]: #UnlinkActiveInteractorCollisions
+[UntouchAllTouchingInteractors()]: #UntouchAllTouchingInteractors

--- a/Runtime/Interactables/SharedResources/NestedPrefabs/Interactable.TouchReceiver.prefab
+++ b/Runtime/Interactables/SharedResources/NestedPrefabs/Interactable.TouchReceiver.prefab
@@ -43,6 +43,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -120,8 +121,15 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Data.Operation.Extraction.GameObjectExtractor+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Zinnia.Tracking.Collision.Active.Operation.Extraction.PublisherContainerExtractor+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  source:
+    sourceContainer: {fileID: 0}
 --- !u!114 &396135878660418311
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -134,6 +142,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -340,8 +349,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Data.Operation.Extraction.GameObjectExtractor+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Zinnia.Tracking.Collision.Active.Operation.Extraction.NotifierContainerExtractor+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  source:
+    forwardSource: {fileID: 0}
+    isTrigger: 0
+    colliderData: {fileID: 0}
 --- !u!1 &3192123263616847461
 GameObject:
   m_ObjectHideFlags: 0
@@ -615,8 +633,11 @@ MonoBehaviour:
   touchConsumer: {fileID: 7941858924651200902}
   untouchConsumer: {fileID: 7290293061507625378}
   currentTouchingObjects: {fileID: 7807029298508291166}
+  currentUntouchingObjects: {fileID: 2496996295341015413}
+  currentUntouchingEventProxy: {fileID: 396135878660418311}
   touchValidity: {fileID: 8509791108597112804}
   potentialInteractors: {fileID: 5698463516239623407}
+  activeInteractorCounter: {fileID: 590885437469876201}
   addActiveInteractor: {fileID: 7318583696533420050}
   removeActiveInteractor: {fileID: 4581025933994455743}
 --- !u!1 &5422430973818856654
@@ -694,6 +715,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -769,8 +791,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Data.Operation.Extraction.GameObjectExtractor+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Zinnia.Tracking.Collision.Active.Operation.Extraction.NotifierContainerExtractor+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  source:
+    forwardSource: {fileID: 0}
+    isTrigger: 0
+    colliderData: {fileID: 0}
 --- !u!1 &7656249435987674889
 GameObject:
   m_ObjectHideFlags: 0
@@ -814,6 +845,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -1004,8 +1036,15 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Data.Operation.Extraction.GameObjectExtractor+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_TypeName: Zinnia.Tracking.Collision.Active.Operation.Extraction.PublisherContainerExtractor+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  source:
+    sourceContainer: {fileID: 0}
 --- !u!114 &7807029298508291166
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
@@ -95,6 +95,22 @@
         #endregion
 
         /// <summary>
+        /// The <see cref="Rigidbody"/> attached to the Interactable.
+        /// </summary>
+        public Rigidbody InteractableRigidbody => Configuration.ConsumerRigidbody;
+        /// <summary>
+        /// The mesh container.
+        /// </summary>
+        public GameObject MeshContainer => Configuration.MeshContainer;
+        /// <summary>
+        /// Returns a <see cref="MeshRenderer"/> collection of all the <see cref="MeshContainer"/> child meshes.
+        /// </summary>
+        public MeshRenderer[] Meshes => MeshContainer.GetComponentsInChildren<MeshRenderer>();
+        /// <summary>
+        /// Returns a <see cref="Collider"/> collection of all the <see cref="MeshContainer"/> child colliders.
+        /// </summary>
+        public Collider[] Colliders => MeshContainer.GetComponentsInChildren<Collider>();
+        /// <summary>
         /// A collection of Interactors that are currently touching the Interactable.
         /// </summary>
         public IReadOnlyList<InteractorFacade> TouchingInteractors => Configuration.TouchConfiguration.TouchingInteractors;
@@ -114,6 +130,22 @@
         /// Whether the Interactable is currently being grabbed by any valid Interactor.
         /// </summary>
         public bool IsGrabbed => GrabbingInteractors.Count > 0;
+        /// <summary>
+        /// Whether the touch functionality is enabled.
+        /// </summary>
+        public bool TouchEnabled => Configuration.TouchConfiguration.TouchConsumer.gameObject.activeInHierarchy && Configuration.TouchConfiguration.UntouchConsumer.gameObject.activeInHierarchy;
+        /// <summary>
+        /// Whether the grab functionality is enabled.
+        /// </summary>
+        public bool GrabEnabled => Configuration.GrabConfiguration.gameObject.activeInHierarchy;
+        /// <summary>
+        /// Whether the primary grab action functionality is enabled.
+        /// </summary>
+        public bool PrimaryGrabEnabled => Configuration.GrabConfiguration.PrimaryAction.gameObject.activeInHierarchy;
+        /// <summary>
+        /// Whether the secondary grab action functionality is enabled.
+        /// </summary>
+        public bool SecondaryGrabEnabled => Configuration.GrabConfiguration.PrimaryAction.gameObject.activeInHierarchy;
 
         /// <summary>
         /// The routine for grabbing after a certain instruction.
@@ -272,6 +304,76 @@
             }
 
             ungrabRoutine = StartCoroutine(DoUngrabAtEndOfFrame(sequenceIndex));
+        }
+
+        /// <summary>
+        /// Enables the touch logic.
+        /// </summary>
+        public virtual void EnableTouch()
+        {
+            Configuration.TouchConfiguration.TouchConsumer.gameObject.SetActive(true);
+            Configuration.TouchConfiguration.UntouchConsumer.gameObject.SetActive(true);
+        }
+
+        /// <summary>
+        /// Disables the touch logic.
+        /// </summary>
+        public virtual void DisableTouch()
+        {
+            Configuration.TouchConfiguration.UntouchAllTouchingInteractors();
+            Configuration.TouchConfiguration.TouchConsumer.gameObject.SetActive(false);
+            Configuration.TouchConfiguration.UntouchConsumer.gameObject.SetActive(false);
+        }
+
+        /// <summary>
+        /// Enables the grab logic.
+        /// </summary>
+        public virtual void EnableGrab()
+        {
+            Configuration.GrabConfiguration.gameObject.SetActive(true);
+        }
+
+        /// <summary>
+        /// Disables the grab logic.
+        /// </summary>
+        public virtual void DisableGrab()
+        {
+            Ungrab();
+            Configuration.GrabConfiguration.gameObject.SetActive(false);
+        }
+
+        /// <summary>
+        /// Enables the primary grab action logic.
+        /// </summary>
+        public virtual void EnablePrimaryGrabAction()
+        {
+            Configuration.GrabConfiguration.PrimaryAction.gameObject.SetActive(true);
+        }
+
+        /// <summary>
+        /// Disables the primary grab action logic.
+        /// </summary>
+        public virtual void DisablePrimaryGrabAction()
+        {
+            Configuration.GrabConfiguration.Ungrab(0);
+            Configuration.GrabConfiguration.PrimaryAction.gameObject.SetActive(false);
+        }
+
+        /// <summary>
+        /// Enables the secondary grab action logic.
+        /// </summary>
+        public virtual void EnableSecondaryGrabAction()
+        {
+            Configuration.GrabConfiguration.SecondaryAction.gameObject.SetActive(true);
+        }
+
+        /// <summary>
+        /// Disables the secondary grab action logic.
+        /// </summary>
+        public virtual void DisableSecondaryGrabAction()
+        {
+            Configuration.GrabConfiguration.Ungrab(1);
+            Configuration.GrabConfiguration.SecondaryAction.gameObject.SetActive(false);
         }
 
         /// <summary>


### PR DESCRIPTION
The InteractableFacade now has some common helper methods for
tasks like enabling/disabling the touch and grab configurations
in case of toggling the interactable behaviour.

It is also possible to get access to common sub components from
the facade such as the Rigidbody, MeshContainer, a collection
of MeshRenderers and a collection of Colliders.

The Interactable.TouchReceiver prefab has also been updated to
contain additional useful references.