### PR TITLE
feat(Interactions): allow follow as standard secondary action

### DIFF
--- a/Editor/Interactables/InteractableFacadeEditor.cs
+++ b/Editor/Interactables/InteractableFacadeEditor.cs
@@ -17,7 +17,7 @@
     public class InteractableFacadeEditor : InspectorEditor
     {
         private static readonly int[] primaryActionsIndexes = new int[] { 0, 1 };
-        private static readonly int[] secondaryActionsIndexes = new int[] { 0, 2, 3, 4 };
+        private static readonly int[] secondaryActionsIndexes = new int[] { 0, 1, 2, 3, 4 };
 
         private string[] primaryActions = new string[0];
         private string[] secondaryActions = new string[0];
@@ -63,6 +63,8 @@
                 grabConfigurationIsDirty = true;
             }
             currentSecondaryActionIndex = selectedSecondaryActionIndex;
+
+            DrawFollowActionSettings(facade, facade.Configuration.GrabConfiguration.SecondaryAction, undoRedoWarningPropertyPath);
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Disallowed Touch Interactor Settings", EditorStyles.boldLabel);

--- a/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.None.prefab
+++ b/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.None.prefab
@@ -43,10 +43,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Event.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
+    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
@@ -93,10 +94,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Event.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
+    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
@@ -109,7 +111,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 892973693970587573}
-  - component: {fileID: 9040303533773360542}
+  - component: {fileID: 2585577160392280173}
   m_Layer: 0
   m_Name: Interactable.GrabAction.None
   m_TagString: Untagged
@@ -132,7 +134,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &9040303533773360542
+--- !u!114 &2585577160392280173
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -141,7 +143,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2708583508217938769}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 507f23209e061f448814c49cf7e72341, type: 3}
+  m_Script: {fileID: 11500000, guid: 3b5b0b0113d2ea44ab41c79ed990cd70, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   inputActiveCollisionConsumer: {fileID: 1268936911278604069}
@@ -227,10 +229,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Event.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
+    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
@@ -277,10 +280,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8fb209bebc91e714ba9375ca64ebc454, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload:
+    publisher:
+      sourceContainer: {fileID: 0}
+    currentCollision:
+      forwardSource: {fileID: 0}
+      isTrigger: 0
+      colliderData: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Event.ActiveCollisionConsumerEventProxyEmitter+UnityEvent,
+    m_TypeName: Zinnia.Tracking.Collision.Active.Event.Proxy.ActiveCollisionConsumerEventProxyEmitter+UnityEvent,
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
@@ -327,10 +337,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Event.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
+    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableNullAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableNullAction.cs
@@ -1,0 +1,7 @@
+﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Action
+{
+    /// <summary>
+    /// Describes an action that performs no action.
+    /// </summary>
+    public class GrabInteractableNullAction : GrabInteractableAction { }
+}

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableNullAction.cs.meta
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableNullAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b5b0b0113d2ea44ab41c79ed990cd70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
@@ -154,7 +154,7 @@
                 return;
             }
 
-            if (Facade.GrabbingInteractors.Count == 1)
+            if (Facade.GrabbingInteractors.Count == 1 || PrimaryGrabIsNone(1))
             {
                 Facade.FirstGrabbed?.Invoke(interactor);
             }
@@ -176,7 +176,7 @@
 
             Facade.Ungrabbed?.Invoke(interactor);
             interactor.NotifyOfUngrab(Facade);
-            if (Facade.GrabbingInteractors.Count == 0)
+            if (Facade.GrabbingInteractors.Count == 0 || PrimaryGrabIsNone(0))
             {
                 Facade.LastUngrabbed?.Invoke(interactor);
             }
@@ -300,6 +300,9 @@
             GrabReceiver.OutputActiveCollisionConsumer.Emitted.AddListener(PrimaryAction.InputActiveCollisionConsumer.Receive);
             GrabProvider.OutputPrimaryGrabAction.Emitted.AddListener(PrimaryAction.InputGrabReceived.Receive);
             GrabProvider.OutputPrimaryUngrabAction.Emitted.AddListener(PrimaryAction.InputUngrabReceived.Receive);
+
+            GrabProvider.OutputPrimaryGrabAction.Emitted.AddListener(EnableSecondaryInputActiveCollisionConsumer);
+            GrabProvider.OutputPrimaryUngrabAction.Emitted.AddListener(DisableSecondaryInputActiveCollisionConsumer);
         }
 
         /// <summary>
@@ -315,6 +318,9 @@
             GrabReceiver.OutputActiveCollisionConsumer.Emitted.RemoveListener(PrimaryAction.InputActiveCollisionConsumer.Receive);
             GrabProvider.OutputPrimaryGrabAction.Emitted.RemoveListener(PrimaryAction.InputGrabReceived.Receive);
             GrabProvider.OutputPrimaryUngrabAction.Emitted.RemoveListener(PrimaryAction.InputUngrabReceived.Receive);
+
+            GrabProvider.OutputPrimaryGrabAction.Emitted.RemoveListener(EnableSecondaryInputActiveCollisionConsumer);
+            GrabProvider.OutputPrimaryUngrabAction.Emitted.RemoveListener(DisableSecondaryInputActiveCollisionConsumer);
         }
 
         /// <summary>
@@ -332,6 +338,8 @@
             GrabProvider.OutputPrimaryUngrabResetOnSecondaryAction.Emitted.AddListener(SecondaryAction.InputUngrabReset.Receive);
             GrabProvider.OutputSecondaryGrabAction.Emitted.AddListener(SecondaryAction.InputGrabReceived.Receive);
             GrabProvider.OutputSecondaryUngrabAction.Emitted.AddListener(SecondaryAction.InputUngrabReceived.Receive);
+
+            DisableSecondaryInputActiveCollisionConsumer(null);
         }
 
         /// <summary>
@@ -349,6 +357,34 @@
             GrabProvider.OutputPrimaryUngrabResetOnSecondaryAction.Emitted.RemoveListener(SecondaryAction.InputUngrabReset.Receive);
             GrabProvider.OutputSecondaryGrabAction.Emitted.RemoveListener(SecondaryAction.InputGrabReceived.Receive);
             GrabProvider.OutputSecondaryUngrabAction.Emitted.RemoveListener(SecondaryAction.InputUngrabReceived.Receive);
+        }
+
+        /// <summary>
+        /// Determines whether the primary grab action is of type <see cref="GrabInteractableNullAction"/>.
+        /// </summary>
+        /// <param name="interactorCount">The amount of grabbing Interactors.</param>
+        /// <returns>Whether the primary grab is of type <see cref="GrabInteractableNullAction"/>.</returns>
+        protected virtual bool PrimaryGrabIsNone(int interactorCount)
+        {
+            return Facade.GrabbingInteractors.Count > interactorCount && PrimaryAction.GetType() == typeof(GrabInteractableNullAction);
+        }
+
+        /// <summary>
+        /// Enables the Secondary Input Active Collision Consumer component.
+        /// </summary>
+        /// <param name="_">unused</param>
+        protected virtual void EnableSecondaryInputActiveCollisionConsumer(GameObject _)
+        {
+            SecondaryAction.InputActiveCollisionConsumer.enabled = true;
+        }
+
+        /// <summary>
+        /// Disables the Secondary Input Active Collision Consumer component.
+        /// </summary>
+        /// <param name="_">unused</param>
+        protected virtual void DisableSecondaryInputActiveCollisionConsumer(GameObject _)
+        {
+            SecondaryAction.InputActiveCollisionConsumer.enabled = false;
         }
 
         /// <summary>


### PR DESCRIPTION
The secondary action can now also be set to follow, which allows the
primary action to be set to none so the primary action does nothing
whereas the secondary action will then grab the item to mimic two
hand grabbing.

The None action now has its own null action rather than just using the
base action so it can be easily identified as a nothing action.