### PR TITLE
fix(Interactions): use VelocityTracker on Interactor

### DIFF
--- a/Documentation/API/Interactors/InteractorFacade.md
+++ b/Documentation/API/Interactors/InteractorFacade.md
@@ -235,12 +235,12 @@ public IReadOnlyList<GameObject> TouchedObjects { get; }
 
 #### VelocityTracker
 
-The VelocityTrackerProcessor to measure the interactors current velocity.
+The [VelocityTracker] to measure the interactors current velocity.
 
 ##### Declaration
 
 ```
-public VelocityTrackerProcessor VelocityTracker { get; set; }
+public VelocityTracker VelocityTracker { get; set; }
 ```
 
 ### Methods
@@ -620,6 +620,7 @@ public virtual void Ungrab()
 [GrabInteractorConfigurator]: GrabInteractorConfigurator.md
 [GrabAction]: InteractorFacade.md#GrabAction
 [TouchInteractorConfigurator]: TouchInteractorConfigurator.md
+[VelocityTracker]: InteractorFacade.md#VelocityTracker
 [InteractableFacade]: ../Interactables/InteractableFacade.md
 [InteractorFacade]: InteractorFacade.md
 [GrabAction]: InteractorFacade.md#GrabAction

--- a/Documentation/API/Interactors/InteractorFacadeSettingsModifier.InteractorElement.md
+++ b/Documentation/API/Interactors/InteractorFacadeSettingsModifier.InteractorElement.md
@@ -81,12 +81,12 @@ protected float cachedGrabPrecognition
 
 #### cachedVelocityTracker
 
-The original VelocityTrackerProcessor on the [TargetFacade] to revert back to.
+The original VelocityTracker on the [TargetFacade] to revert back to.
 
 ##### Declaration
 
 ```
-protected VelocityTrackerProcessor cachedVelocityTracker
+protected VelocityTracker cachedVelocityTracker
 ```
 
 ### Properties
@@ -123,12 +123,12 @@ public float TargetGrabPrecognition { get; set; }
 
 #### TargetVelocityTracker
 
-The VelocityTrackerProcessor to update the [VelocityTracker] to.
+The VelocityTracker to update the [VelocityTracker] to.
 
 ##### Declaration
 
 ```
-public VelocityTrackerProcessor TargetVelocityTracker { get; set; }
+public VelocityTracker TargetVelocityTracker { get; set; }
 ```
 
 ### Methods

--- a/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
@@ -35,11 +35,11 @@
         [field: Header("Interactor Settings"), DocumentedByXml]
         public BooleanAction GrabAction { get; set; }
         /// <summary>
-        /// The <see cref="VelocityTrackerProcessor"/> to measure the interactors current velocity.
+        /// The <see cref="VelocityTracker"/> to measure the interactors current velocity.
         /// </summary>
         [Serialized, Cleared]
         [field: DocumentedByXml]
-        public VelocityTrackerProcessor VelocityTracker { get; set; }
+        public VelocityTracker VelocityTracker { get; set; }
         /// <summary>
         /// The time between initiating the <see cref="GrabAction"/> and touching an Interactable to be considered a valid grab.
         /// </summary>

--- a/Runtime/Interactors/SharedResources/Scripts/InteractorFacadeSettingsModifier.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/InteractorFacadeSettingsModifier.cs
@@ -32,11 +32,11 @@
             [field: DocumentedByXml]
             public BooleanAction TargetGrabAction { get; set; }
             /// <summary>
-            /// The <see cref="VelocityTrackerProcessor"/> to update the <see cref="InteractorFacade.VelocityTracker"/> to.
+            /// The <see cref="VelocityTracker"/> to update the <see cref="InteractorFacade.VelocityTracker"/> to.
             /// </summary>
             [Serialized, Cleared]
             [field: DocumentedByXml]
-            public VelocityTrackerProcessor TargetVelocityTracker { get; set; }
+            public VelocityTracker TargetVelocityTracker { get; set; }
             /// <summary>
             /// The updated value to set the <see cref="InteractorFacade.GrabPrecognition"/> to.
             /// </summary>
@@ -49,9 +49,9 @@
             /// </summary>
             protected BooleanAction cachedGrabAction;
             /// <summary>
-            /// The original <see cref="VelocityTrackerProcessor"/> on the <see cref="TargetFacade"/> to revert back to.
+            /// The original <see cref="VelocityTracker"/> on the <see cref="TargetFacade"/> to revert back to.
             /// </summary>
-            protected VelocityTrackerProcessor cachedVelocityTracker;
+            protected VelocityTracker cachedVelocityTracker;
             /// <summary>
             /// The original <see cref="GrabPrecognition"/> on the <see cref="TargetFacade"/> to revert back to.
             /// </summary>


### PR DESCRIPTION
The Interactor would require a VelocityTrackerProcessor but this
limited the usage and as it just extends the VelocityTracker then
it makes sense for the Interactor to just take a VelocityTracker
and this shouldn't break any prefab links either.