### PR TITLE
fix(Interactions): remove erroneous xml doc from editor

### DIFF
--- a/Editor/Interactables/InteractableFacadeEditor.cs
+++ b/Editor/Interactables/InteractableFacadeEditor.cs
@@ -10,9 +10,6 @@
     using Zinnia.Rule;
     using Zinnia.Tracking.Follow.Modifier.Property.Rotation;
 
-    /// <summary>
-    /// 
-    /// </summary>
     [CustomEditor(typeof(InteractableFacade), true)]
     public class InteractableFacadeEditor : InspectorEditor
     {


### PR DESCRIPTION
The InteractableFacadeEditor had an empty XML doc at the top of the
class which isn't needed.