### PR TITLE
feat(prefabs): update ControlDirection to implement follow TargetOffset

### DIFF
--- a/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.ControlDirection.prefab
+++ b/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.ControlDirection.prefab
@@ -43,6 +43,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -163,6 +164,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -318,6 +320,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -424,6 +427,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 3677352096674154965}
+        m_MethodName: ClearTargetOffset
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!1 &2719784054965154528
@@ -470,6 +484,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -681,6 +696,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -777,6 +793,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -807,7 +824,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2157e287d17f1224d975060d2f815cd7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 0}
   Extracted:
     m_PersistentCalls:
       m_Calls:
@@ -829,6 +845,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  source: {fileID: 0}
 --- !u!114 &6600852539105904702
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -841,7 +858,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 13042f90e16b7fa449a4e044e1fedb54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 0}
   Extracted:
     m_PersistentCalls:
       m_Calls:
@@ -863,6 +879,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  source: {fileID: 0}
 --- !u!1 &4827555627255761747
 GameObject:
   m_ObjectHideFlags: 0
@@ -906,6 +923,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -1028,9 +1046,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 1717138987862005321}
+        m_MethodName: SetupTargetOffset
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 6185872906043298336}
         m_MethodName: DoExtract
         m_Mode: 0
@@ -1058,7 +1088,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2157e287d17f1224d975060d2f815cd7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 0}
   Extracted:
     m_PersistentCalls:
       m_Calls:
@@ -1080,6 +1109,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  source: {fileID: 0}
 --- !u!114 &6185872906043298336
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1092,7 +1122,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 13042f90e16b7fa449a4e044e1fedb54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 0}
   Extracted:
     m_PersistentCalls:
       m_Calls:
@@ -1114,6 +1143,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+  source: {fileID: 0}
 --- !u!1 &5809530935915426154
 GameObject:
   m_ObjectHideFlags: 0
@@ -1163,8 +1193,10 @@ MonoBehaviour:
   target: {fileID: 0}
   lookAt: {fileID: 0}
   pivot: {fileID: 0}
+  targetOffset: {fileID: 0}
+  rotationUpTarget: 1
+  snapToLookAt: 1
   resetOrientationSpeed: 0.1
-  preventLookAtZRotation: 1
   OrientationReset:
     m_PersistentCalls:
       m_Calls:
@@ -1250,6 +1282,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []
@@ -1395,6 +1432,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -1459,6 +1497,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -1542,6 +1581,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -1676,6 +1716,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls:
@@ -1759,6 +1800,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8fb209bebc91e714ba9375ca64ebc454, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  payload:
+    publisher:
+      sourceContainer: {fileID: 0}
+    currentCollision:
+      forwardSource: {fileID: 0}
+      isTrigger: 0
+      colliderData: {fileID: 0}
   Emitted:
     m_PersistentCalls:
       m_Calls: []
@@ -1766,3 +1814,4 @@ MonoBehaviour:
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
+  ruleSource: 0

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableControlDirectionAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableControlDirectionAction.cs
@@ -44,6 +44,47 @@
         }
 
         /// <summary>
+        /// Sets up the <see cref="DirectionModifier.TargetOffset"/> based on the target offsets from any follow action.
+        /// </summary>
+        public virtual void SetupTargetOffset()
+        {
+            if (GrabSetup == null)
+            {
+                return;
+            }
+
+            if (GrabSetup.SecondaryAction == this)
+            {
+                LinkTargetOffsets(GrabSetup.PrimaryAction);
+            }
+            else if (GrabSetup.PrimaryAction == this)
+            {
+                LinkTargetOffsets(GrabSetup.SecondaryAction);
+            }
+        }
+
+        /// <summary>
+        /// Links the given action's target offset to the <see cref="DirectionModifier.TargetOffset"/> if the action is a Follow Action.
+        /// </summary>
+        /// <param name="action">The action to try and link from.</param>
+        protected virtual void LinkTargetOffsets(GrabInteractableAction action)
+        {
+            if (!typeof(GrabInteractableFollowAction).IsAssignableFrom(action.GetType()))
+            {
+                return;
+            }
+
+            GrabInteractableFollowAction followAction = (GrabInteractableFollowAction)action;
+
+            if (followAction == null || followAction.ObjectFollower == null || followAction.ObjectFollower.TargetOffsets == null)
+            {
+                return;
+            }
+
+            DirectionModifier.TargetOffset = followAction.ObjectFollower.TargetOffsets.NonSubscribableElements.Count > 0 ? followAction.ObjectFollower.TargetOffsets.NonSubscribableElements[0] : null;
+        }
+
+        /// <summary>
         /// Toggles the <see cref="GameObject"/> state of each of the items in the <see cref="LinkedObjects"/> collection.
         /// </summary>
         /// <param name="state">The state to set the <see cref="GameObject"/> active state to.</param>


### PR DESCRIPTION
The latest version of the DirectionModifier now allows for a
TargetOffset to be provided, which can be provided from any Follow
action as they also consider a TargetOffset. The first found
TargetOffset of a complimentary follow action on an interactable will
be used as the TargetOffset on the ControlDirection Directionmodifier.