### PR TITLE
fix(Proxy): prevent null exception in event proxies

### DIFF
--- a/Runtime/Interactables/SharedResources/Scripts/Event/Proxy/InteractableFacadeEventProxyEmitter.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Event/Proxy/InteractableFacadeEventProxyEmitter.cs
@@ -20,7 +20,7 @@
         /// <inheritdoc />
         protected override object GetTargetToCheck()
         {
-            return Payload.gameObject;
+            return Payload != null ? Payload.gameObject : null;
         }
     }
 }

--- a/Runtime/Interactors/SharedResources/Scripts/Event/Proxy/InteractorFacadeEventProxyEmitter.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/Event/Proxy/InteractorFacadeEventProxyEmitter.cs
@@ -20,7 +20,7 @@
         /// <inheritdoc />
         protected override object GetTargetToCheck()
         {
-            return Payload.gameObject;
+            return Payload != null ? Payload.gameObject : null;
         }
     }
 }


### PR DESCRIPTION
There was an issue where an event proxy could be called but the Payload
was null causing a null exception to occur. This has now been guarded
against.