### PR TITLE
feat(Rule): add rules for interactor touch and grab state

### DIFF
--- a/Runtime/Interactors/SharedResources/Scripts/Rule.meta
+++ b/Runtime/Interactors/SharedResources/Scripts/Rule.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d9538290f3b14c4faa263a7206e4bec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsGrabbingRule.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsGrabbingRule.cs
@@ -1,0 +1,14 @@
+﻿namespace Tilia.Interactions.Interactables.Interactors.Rule
+{
+    /// <summary>
+    /// Determines whether the Interactor is currently grabbing something.
+    /// </summary>
+    public class InteractorIsGrabbingRule : InteractorRule
+    {
+        /// <inheritdoc />
+        protected override bool Accepts(InteractorFacade targetInteractorFacade)
+        {
+            return targetInteractorFacade.GrabbedObjects.Count > 0;
+        }
+    }
+}

--- a/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsGrabbingRule.cs.meta
+++ b/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsGrabbingRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2868bddd5ce35974e934010ade93c0ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsTouchingRule.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsTouchingRule.cs
@@ -1,0 +1,14 @@
+﻿namespace Tilia.Interactions.Interactables.Interactors.Rule
+{
+    /// <summary>
+    /// Determines whether the Interactor is currently touching something.
+    /// </summary>
+    public class InteractorIsTouchingRule : InteractorRule
+    {
+        /// <inheritdoc />
+        protected override bool Accepts(InteractorFacade targetInteractorFacade)
+        {
+            return targetInteractorFacade.TouchedObjects.Count > 0;
+        }
+    }
+}

--- a/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsTouchingRule.cs.meta
+++ b/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorIsTouchingRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 801acba9ee05fa24681a71ca8914fdd8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorRule.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorRule.cs
@@ -1,0 +1,47 @@
+﻿namespace Tilia.Interactions.Interactables.Interactors.Rule
+{
+    using UnityEngine;
+    using Zinnia.Rule;
+
+    /// <summary>
+    /// Simplifies implementing <see cref="IRule"/>s that only deals with an <see cref="InteractorRule"/> attached to a <see cref="GameObject"/>.
+    /// </summary>
+    public abstract class InteractorRule : GameObjectRule
+    {
+        /// <summary>
+        /// A cache to store the given <see cref="GameObject"/> to prevent having to re execute the <see cref="GameObject.GetComponent{T}"/> method on the same given <see cref="GameObject"/>.
+        /// </summary>
+        protected GameObject cachedGameObject;
+        /// <summary>
+        /// The cached <see cref="InteractorFacade"/> to check the grabbed state on.
+        /// </summary>
+        protected InteractorFacade cachedInteractor;
+
+        /// <summary>
+        /// Determines whether a <see cref="InteractorFacade"/> is accepted.
+        /// </summary>
+        /// <param name="interactor">The <see cref="InteractorFacade"/> to check.</param>
+        /// <returns><see langword="true"/> if <paramref name="targetInteractorFacade"/> is accepted, <see langword="false"/> otherwise.</returns>
+        protected abstract bool Accepts(InteractorFacade targetInteractorFacade);
+
+        /// <inheritdoc />
+        protected override bool Accepts(GameObject targetGameObject)
+        {
+            if (cachedGameObject != targetGameObject || cachedInteractor == null)
+            {
+                cachedInteractor = targetGameObject.GetComponent<InteractorFacade>();
+                if (cachedInteractor != null)
+                {
+                    cachedGameObject = targetGameObject;
+                }
+            }
+
+            if (cachedInteractor == null)
+            {
+                return false;
+            }
+
+            return Accepts(cachedInteractor);
+        }
+    }
+}

--- a/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorRule.cs.meta
+++ b/Runtime/Interactors/SharedResources/Scripts/Rule/InteractorRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6028c5eb7e3b01c4e9f853587a8bec6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The new rules will be able to determine if a given GameObject has
an InteractorFacade on it and if it does then whether the given
Interactor is either currently touching or grabbing something.