### PR TITLE
feat(Interactor): add ability to simulate a touch with no collision

### DIFF
--- a/Documentation/API/Interactables/Touch/TouchInteractableConfigurator.md
+++ b/Documentation/API/Interactables/Touch/TouchInteractableConfigurator.md
@@ -6,6 +6,7 @@
 * [Namespace]
 * [Syntax]
 * [Fields]
+  * [isFirstTouched]
   * [touchingInteractors]
 * [Properties]
   * [ActiveInteractorCounter]
@@ -50,6 +51,16 @@ public class TouchInteractableConfigurator : MonoBehaviour
 ```
 
 ### Fields
+
+#### isFirstTouched
+
+Whether this is being first touched.
+
+##### Declaration
+
+```
+protected bool isFirstTouched
+```
 
 #### touchingInteractors
 
@@ -312,6 +323,7 @@ public virtual void UntouchAllTouchingInteractors()
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Fields]: #Fields
+[isFirstTouched]: #isFirstTouched
 [touchingInteractors]: #touchingInteractors
 [Properties]: #Properties
 [ActiveInteractorCounter]: #ActiveInteractorCounter

--- a/Documentation/API/Interactors/InteractorFacade.md
+++ b/Documentation/API/Interactors/InteractorFacade.md
@@ -29,6 +29,7 @@ The public interface into the Interactor Prefab.
 * [Methods]
   * [ClearGrabState(InteractableFacade)]
   * [ClearGrabStateAtEndOfFrame(InteractableFacade)]
+  * [CreateCollisionPayload(GameObject)]
   * [Grab(GameObject)]
   * [Grab(GameObject, Boolean)]
   * [Grab(SurfaceData)]
@@ -48,6 +49,10 @@ The public interface into the Interactor Prefab.
   * [OnAfterGrabActionChange()]
   * [OnAfterGrabPrecognitionChange()]
   * [OnAfterVelocityTrackerChange()]
+  * [SimulateTouch(GameObject)]
+  * [SimulateTouch(InteractableFacade)]
+  * [SimulateUntouch(GameObject)]
+  * [SimulateUntouch(InteractableFacade)]
   * [SnapAllGrabbedInteractableOrientations()]
   * [SnapGrabbedInteractableOrientation(Int32)]
   * [Ungrab()]
@@ -282,6 +287,28 @@ protected virtual IEnumerator ClearGrabStateAtEndOfFrame(InteractableFacade inte
 | Type | Description |
 | --- | --- |
 | System.Collections.IEnumerator | An Enumerator to manage the running of the Coroutine. |
+
+#### CreateCollisionPayload(GameObject)
+
+Creates a collision payload for a given Interactable GameObject
+
+##### Declaration
+
+```
+protected virtual CollisionNotifier.EventData CreateCollisionPayload(GameObject interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | interactable | The GameObject that the Interactable is on. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| CollisionNotifier.EventData | A collision payload. |
 
 #### Grab(GameObject)
 
@@ -579,6 +606,70 @@ Called after [VelocityTracker] has been changed.
 protected virtual void OnAfterVelocityTrackerChange()
 ```
 
+#### SimulateTouch(GameObject)
+
+Simulates this Interactor touching a given Interactable.
+
+##### Declaration
+
+```
+public virtual void SimulateTouch(GameObject interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | interactable | The GameObject containing the Interactable. |
+
+#### SimulateTouch(InteractableFacade)
+
+Simulates this Interactor touching a given Interactable.
+
+##### Declaration
+
+```
+public virtual void SimulateTouch(InteractableFacade interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [InteractableFacade] | interactable | The Interactable. |
+
+#### SimulateUntouch(GameObject)
+
+Simulates this Interactor untouching a given Interactable.
+
+##### Declaration
+
+```
+public virtual void SimulateUntouch(GameObject interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | interactable | The GameObject containing the Interactable. |
+
+#### SimulateUntouch(InteractableFacade)
+
+Simulates this Interactor untouching a given Interactable.
+
+##### Declaration
+
+```
+public virtual void SimulateUntouch(InteractableFacade interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [InteractableFacade] | interactable | The Interactable. |
+
 #### SnapAllGrabbedInteractableOrientations()
 
 Snaps the orientation of all grabbed Interactables to this Interactor.
@@ -651,6 +742,7 @@ public virtual void Ungrab()
 [Methods]: #Methods
 [ClearGrabState(InteractableFacade)]: #ClearGrabStateInteractableFacade
 [ClearGrabStateAtEndOfFrame(InteractableFacade)]: #ClearGrabStateAtEndOfFrameInteractableFacade
+[CreateCollisionPayload(GameObject)]: #CreateCollisionPayloadGameObject
 [Grab(GameObject)]: #GrabGameObject
 [Grab(GameObject, Boolean)]: #GrabGameObject-Boolean
 [Grab(SurfaceData)]: #GrabSurfaceData
@@ -670,6 +762,10 @@ public virtual void Ungrab()
 [OnAfterGrabActionChange()]: #OnAfterGrabActionChange
 [OnAfterGrabPrecognitionChange()]: #OnAfterGrabPrecognitionChange
 [OnAfterVelocityTrackerChange()]: #OnAfterVelocityTrackerChange
+[SimulateTouch(GameObject)]: #SimulateTouchGameObject
+[SimulateTouch(InteractableFacade)]: #SimulateTouchInteractableFacade
+[SimulateUntouch(GameObject)]: #SimulateUntouchGameObject
+[SimulateUntouch(InteractableFacade)]: #SimulateUntouchInteractableFacade
 [SnapAllGrabbedInteractableOrientations()]: #SnapAllGrabbedInteractableOrientations
 [SnapGrabbedInteractableOrientation(Int32)]: #SnapGrabbedInteractableOrientationInt32
 [Ungrab()]: #Ungrab

--- a/Runtime/Interactables/SharedResources/Scripts/Touch/TouchInteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Touch/TouchInteractableConfigurator.cs
@@ -103,6 +103,10 @@
         /// A reusable collection to hold the returned touching interactors.
         /// </summary>
         protected readonly List<InteractorFacade> touchingInteractors = new List<InteractorFacade>();
+        /// <summary>
+        /// Whether this is being first touched.
+        /// </summary>
+        protected bool isFirstTouched;
 
         /// <summary>
         /// Enforces that all the existing touching interactors are no longer actually touching.
@@ -124,8 +128,9 @@
             InteractorFacade interactor = data.TryGetComponent<InteractorFacade>(true, true);
             if (interactor != null)
             {
-                if (TouchingInteractors.Count == 1)
+                if (TouchingInteractors.Count <= 1 && !isFirstTouched)
                 {
+                    isFirstTouched = true;
                     Facade.FirstTouched?.Invoke(interactor);
                 }
                 Facade.Touched?.Invoke(interactor);
@@ -146,6 +151,7 @@
                 interactor.NotifyOfUntouch(Facade);
                 if (TouchingInteractors.Count == 0)
                 {
+                    isFirstTouched = false;
                     Facade.LastUntouched?.Invoke(interactor);
                 }
             }

--- a/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
@@ -182,6 +182,7 @@
                 Ungrab();
             }
 
+            Facade.SimulateTouch(interactable);
             StartGrabbingPublisher.SetActiveCollisions(CreateActiveCollisionsEventData(interactable.gameObject, collision, collider));
             ProcessGrabAction(StartGrabbingPublisher, true);
             if (interactable.IsGrabTypeToggle)

--- a/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
@@ -14,6 +14,7 @@
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Type;
     using Zinnia.Extension;
+    using Zinnia.Tracking.Collision;
     using Zinnia.Tracking.Velocity;
 
     /// <summary>
@@ -125,6 +126,62 @@
         /// A reusable instance of <see cref="WaitForEndOfFrame"/>.
         /// </summary>
         protected WaitForEndOfFrame delayInstruction = new WaitForEndOfFrame();
+
+        /// <summary>
+        /// Simulates this Interactor touching a given Interactable.
+        /// </summary>
+        /// <param name="interactable">The GameObject containing the Interactable.</param>
+        public virtual void SimulateTouch(GameObject interactable)
+        {
+            if (interactable == null)
+            {
+                return;
+            }
+
+            GetComponent<CollisionTracker>().OnCollisionStarted(CreateCollisionPayload(interactable));
+        }
+
+        /// <summary>
+        /// Simulates this Interactor touching a given Interactable.
+        /// </summary>
+        /// <param name="interactable">The Interactable.</param>
+        public virtual void SimulateTouch(InteractableFacade interactable)
+        {
+            if (interactable == null)
+            {
+                return;
+            }
+
+            SimulateTouch(interactable.gameObject);
+        }
+
+        /// <summary>
+        /// Simulates this Interactor untouching a given Interactable.
+        /// </summary>
+        /// <param name="interactable">The GameObject containing the Interactable.</param>
+        public virtual void SimulateUntouch(GameObject interactable)
+        {
+            if (interactable == null)
+            {
+                return;
+            }
+
+            GetComponent<CollisionTracker>().OnCollisionStopped(CreateCollisionPayload(interactable));
+        }
+
+        /// <summary>
+        /// Simulates this Interactor untouching a given Interactable.
+        /// </summary>
+        /// <param name="interactable">The Interactable.</param>
+        public virtual void SimulateUntouch(InteractableFacade interactable)
+        {
+            if (interactable == null)
+            {
+                return;
+            }
+
+            SimulateUntouch(interactable.gameObject);
+        }
 
         /// <summary>
         /// Attempt to attach a <see cref="GameObject"/> that contains an <see cref="InteractableFacade"/> to this <see cref="InteractorFacade"/> and ungrabs any existing grab.
@@ -331,6 +388,22 @@
             {
                 interactable.SnapFollowOrientation();
             }
+        }
+
+        /// <summary>
+        /// Creates a collision payload for a given Interactable <see cref="GameObject"/>
+        /// </summary>
+        /// <param name="interactable">The GameObject that the Interactable is on.</param>
+        /// <returns>A collision payload.</returns>
+        protected virtual CollisionNotifier.EventData CreateCollisionPayload(GameObject interactable)
+        {
+            return new CollisionNotifier.EventData()
+            {
+                ForwardSource = GetComponent<CollisionTracker>(),
+                IsTrigger = true,
+                CollisionData = null,
+                ColliderData = interactable.GetComponentInChildren<Collider>()
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
The new SimulateTouch and SimulateUntouch method on the
InteractorFacade allow for the Interactor to effectively touch an
Interactable without needing to physically collide with it in the
spatial world.

The Grab() method has also been updated so it uses this SimulateTouch
before grabbing so all of the correct events are triggered.