### PR TITLE
fix(Interactor): make touch before force grab optional

### DIFF
--- a/Documentation/API/Interactors/GrabInteractorConfigurator.md
+++ b/Documentation/API/Interactors/GrabInteractorConfigurator.md
@@ -21,6 +21,7 @@ Sets up the Interactor Prefab grab settings based on the provided user settings.
   * [PrecognitionTimer]
   * [StartGrabbingPublisher]
   * [StopGrabbingPublisher]
+  * [TouchBeforeForceGrab]
   * [VelocityTracker]
 * [Methods]
   * [ChooseGrabProcessor()]
@@ -176,6 +177,16 @@ The ActiveCollisionPublisher for checking valid stop grabbing action.
 
 ```
 public ActiveCollisionPublisher StopGrabbingPublisher { get; protected set; }
+```
+
+#### TouchBeforeForceGrab
+
+Whether to simulate a touch before force grabbing.
+
+##### Declaration
+
+```
+public bool TouchBeforeForceGrab { get; set; }
 ```
 
 #### VelocityTracker
@@ -385,6 +396,7 @@ public virtual void Ungrab()
 [PrecognitionTimer]: #PrecognitionTimer
 [StartGrabbingPublisher]: #StartGrabbingPublisher
 [StopGrabbingPublisher]: #StopGrabbingPublisher
+[TouchBeforeForceGrab]: #TouchBeforeForceGrab
 [VelocityTracker]: #VelocityTracker
 [Methods]: #Methods
 [ChooseGrabProcessor()]: #ChooseGrabProcessor

--- a/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
@@ -91,6 +91,12 @@
         [Serialized]
         [field: DocumentedByXml, Restricted]
         public BooleanAction IsGrabbingAction { get; protected set; }
+        /// <summary>
+        /// Whether to simulate a touch before force grabbing.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, Restricted]
+        public bool TouchBeforeForceGrab { get; set; } = true;
         #endregion
 
         /// <summary>
@@ -182,7 +188,11 @@
                 Ungrab();
             }
 
-            Facade.SimulateTouch(interactable);
+            if (TouchBeforeForceGrab)
+            {
+                Facade.SimulateTouch(interactable);
+            }
+
             StartGrabbingPublisher.SetActiveCollisions(CreateActiveCollisionsEventData(interactable.gameObject, collision, collider));
             ProcessGrabAction(StartGrabbingPublisher, true);
             if (interactable.IsGrabTypeToggle)


### PR DESCRIPTION
There is an issue with the newly added touch before force grab where
it may not always be desirable to have that functionality and as
the functionality has changed then it should be an option so it can
be disabled and provide the original functionality if need be.