### PR TITLE
feat(Action): provide pivot offset from target offset first found child

### DIFF
--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableControlDirectionAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableControlDirectionAction.cs
@@ -82,6 +82,7 @@
             }
 
             DirectionModifier.TargetOffset = followAction.ObjectFollower.TargetOffsets.NonSubscribableElements.Count > 0 ? followAction.ObjectFollower.TargetOffsets.NonSubscribableElements[0] : null;
+            DirectionModifier.PivotOffset = DirectionModifier.TargetOffset != null && DirectionModifier.TargetOffset.transform.childCount > 0 ? DirectionModifier.TargetOffset.transform.GetChild(0).gameObject : null;
         }
 
         /// <summary>


### PR DESCRIPTION
The DirectionModifier now supports a PivotOffset which is now set by
the first child GameObject found within the TargetOffset GameObject.