### PR TITLE
feat(Interactables): prioritize Interactable root when selecting it from the Scene view

### DIFF
--- a/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
@@ -13,6 +13,7 @@
     /// <summary>
     /// The public interface into the Interactable Prefab.
     /// </summary>
+    [SelectionBase]
     public class InteractableFacade : MonoBehaviour
     {
         /// <summary>

--- a/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/InteractorFacade.cs
@@ -16,6 +16,7 @@
     /// <summary>
     /// The public interface into the Interactor Prefab.
     /// </summary>
+    [SelectionBase]
     public class InteractorFacade : MonoBehaviour
     {
         /// <summary>


### PR DESCRIPTION
Now the Interactable's root gets selected by default when any of it's meshes is clicked in the Scene view. This allows to move Interactables in the Scene more intuitively, without having to explicitly switch to the root object every time.

# Why is it needed?

When working with Interactables it is normal to move them around in the Scene. However, if the Interactable has custom non-prefab mesh inside it, this mesh gets selected when the Interactable is clicked on in the Scene view. This often leads to frustrating situations where one moves a single mesh and the Interactable's root stays in place.
Applying [_SelectionBase_](https://docs.unity3d.com/ScriptReference/SelectionBaseAttribute.html) attribute to the _InteractableFacade_ make Unity select the root of the Interactable first, which makes the Interactable placement workflow more user-friendly and efficient. Individual meshes can still be selected by clicking on them again, making the selection logic identical to the one of prefab objects.

# Quick explanation GIFs

Without _SelectionBase_ attribute:

![interactable_no_selection_base](https://user-images.githubusercontent.com/33633125/166444996-ba0d32db-7deb-4d9a-9040-d8387fc81e0b.gif)

With _SelectionBase_ attribute:

![interactable_selection_base](https://user-images.githubusercontent.com/33633125/166445002-c08354cf-545a-4707-9b42-52e16da2cec7.gif)
