### PR TITLE
feat(Grab): emit event when kinematic state will change

### DIFF
--- a/Documentation/API/Interactables/Grab/GrabInteractableConfigurator.UnityEvent.md
+++ b/Documentation/API/Interactables/Grab/GrabInteractableConfigurator.UnityEvent.md
@@ -1,0 +1,19 @@
+# Class GrabInteractableConfigurator.UnityEvent
+
+Defines the event with the Rigidbody.
+
+##### Inheritance
+
+* System.Object
+* GrabInteractableConfigurator.UnityEvent
+
+###### **Namespace**: [Tilia.Interactions.Interactables.Interactables.Grab]
+
+##### Syntax
+
+```
+[Serializable]
+public class UnityEvent : GrabInteractableConfigurator.UnityEvent<Rigidbody>
+```
+
+[Tilia.Interactions.Interactables.Interactables.Grab]: README.md

--- a/Documentation/API/Interactables/Grab/GrabInteractableConfigurator.UnityEvent.md.meta
+++ b/Documentation/API/Interactables/Grab/GrabInteractableConfigurator.UnityEvent.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 87a097ba8ff0256468098de6b9c91019
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Interactables/Grab/GrabInteractableConfigurator.md
+++ b/Documentation/API/Interactables/Grab/GrabInteractableConfigurator.md
@@ -7,6 +7,8 @@ Sets up the Interactable Prefab grab settings based on the provided user setting
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Fields]
+  * [KinematicStateToChange]
 * [Properties]
   * [ActionTypes]
   * [Facade]
@@ -62,6 +64,16 @@ Sets up the Interactable Prefab grab settings based on the provided user setting
 
 ```
 public class GrabInteractableConfigurator : MonoBehaviour
+```
+
+### Fields
+
+#### KinematicStateToChange
+
+##### Declaration
+
+```
+public GrabInteractableConfigurator.UnityEvent KinematicStateToChange
 ```
 
 ### Properties
@@ -507,6 +519,7 @@ protected virtual void UnlinkToSecondaryAction()
 ```
 
 [Tilia.Interactions.Interactables.Interactables.Grab]: README.md
+[GrabInteractableConfigurator.UnityEvent]: GrabInteractableConfigurator.UnityEvent.md
 [InteractableFacade]: ../../Interactables/InteractableFacade.md
 [InteractorFacade]: ../../Interactors/InteractorFacade.md
 [GrabInteractableInteractorProvider]: Provider/GrabInteractableInteractorProvider.md
@@ -529,6 +542,8 @@ protected virtual void UnlinkToSecondaryAction()
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Fields]: #Fields
+[KinematicStateToChange]: #KinematicStateToChange
 [Properties]: #Properties
 [ActionTypes]: #ActionTypes
 [Facade]: #Facade

--- a/Documentation/API/Interactables/Grab/InteractableGrabStateRegistrar.RigidbodyUnityEvent.md
+++ b/Documentation/API/Interactables/Grab/InteractableGrabStateRegistrar.RigidbodyUnityEvent.md
@@ -1,0 +1,19 @@
+# Class InteractableGrabStateRegistrar.RigidbodyUnityEvent
+
+Defines the event with the specified Rigidbody.
+
+##### Inheritance
+
+* System.Object
+* InteractableGrabStateRegistrar.RigidbodyUnityEvent
+
+###### **Namespace**: [Tilia.Interactions.Interactables.Interactables.Grab]
+
+##### Syntax
+
+```
+[Serializable]
+public class RigidbodyUnityEvent : InteractableGrabStateRegistrar.UnityEvent<Rigidbody>
+```
+
+[Tilia.Interactions.Interactables.Interactables.Grab]: README.md

--- a/Documentation/API/Interactables/Grab/InteractableGrabStateRegistrar.RigidbodyUnityEvent.md.meta
+++ b/Documentation/API/Interactables/Grab/InteractableGrabStateRegistrar.RigidbodyUnityEvent.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bfc1144c6a1731e4488ec30452200cfe
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Interactables/Grab/InteractableGrabStateRegistrar.md
+++ b/Documentation/API/Interactables/Grab/InteractableGrabStateRegistrar.md
@@ -9,6 +9,8 @@ Registers listeners to the initial grab and final ungrab states of an [Interacta
 * [Syntax]
 * [Fields]
   * [Grabbed]
+  * [KinematicStateChangedOnGrabbed]
+  * [KinematicStateChangedOnUngrabbed]
   * [Ungrabbed]
   * [unsubscribeGrabActions]
   * [unsubscribeUngrabActions]
@@ -16,7 +18,9 @@ Registers listeners to the initial grab and final ungrab states of an [Interacta
   * [UnsubscribeOnDisable]
 * [Methods]
   * [InteractableGrabbed(InteractableFacade)]
+  * [InteractableGrabbedKinematicChange(InteractableFacade)]
   * [InteractableUngrabbed(InteractableFacade)]
+  * [InteractableUngrabbedKinematicChange(InteractableFacade)]
   * [OnDisable()]
   * [RegisterGrabbed(GameObject)]
   * [RegisterGrabbed(InteractableFacade)]
@@ -51,12 +55,28 @@ public class InteractableGrabStateRegistrar : MonoBehaviour
 
 #### Grabbed
 
-Emitted when the [InteractableFacade] is grabbed.
-
 ##### Declaration
 
 ```
 public InteractableGrabStateRegistrar.UnityEvent Grabbed
+```
+
+#### KinematicStateChangedOnGrabbed
+
+##### Declaration
+
+```
+public InteractableGrabStateRegistrar.RigidbodyUnityEvent KinematicStateChangedOnGrabbed
+```
+
+#### KinematicStateChangedOnUngrabbed
+
+Emitted when the [InteractableFacade] is about to change the kinematic state of its Rigidbody when ungrabbed.
+
+##### Declaration
+
+```
+public InteractableGrabStateRegistrar.RigidbodyUnityEvent KinematicStateChangedOnUngrabbed
 ```
 
 #### Ungrabbed
@@ -119,6 +139,22 @@ protected virtual void InteractableGrabbed(InteractableFacade interactable)
 | --- | --- | --- |
 | [InteractableFacade] | interactable | The Interactable to process the grab event for. |
 
+#### InteractableGrabbedKinematicChange(InteractableFacade)
+
+Processes the kinematic state change on the grabbed event on the given Interactable.
+
+##### Declaration
+
+```
+protected virtual void InteractableGrabbedKinematicChange(InteractableFacade interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [InteractableFacade] | interactable | The Interactable to process the grab event for. |
+
 #### InteractableUngrabbed(InteractableFacade)
 
 Processes the ungrabbed event on the given Interactable.
@@ -134,6 +170,22 @@ protected virtual void InteractableUngrabbed(InteractableFacade interactable)
 | Type | Name | Description |
 | --- | --- | --- |
 | [InteractableFacade] | interactable | The Interactable to process the ungrab event for. |
+
+#### InteractableUngrabbedKinematicChange(InteractableFacade)
+
+Processes the kinematic state change on the ungrabbed event on the given Interactable.
+
+##### Declaration
+
+```
+protected virtual void InteractableUngrabbedKinematicChange(InteractableFacade interactable)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [InteractableFacade] | interactable | The Interactable to process the grab event for. |
 
 #### OnDisable()
 
@@ -303,12 +355,15 @@ public virtual void UnregisterUngrabbed(InteractableFacade ungrabbable)
 
 [InteractableFacade]: ../../Interactables/InteractableFacade.md
 [Tilia.Interactions.Interactables.Interactables.Grab]: README.md
+[InteractableGrabStateRegistrar.RigidbodyUnityEvent]: InteractableGrabStateRegistrar.RigidbodyUnityEvent.md
 [InteractableGrabStateRegistrar.UnityEvent]: InteractableGrabStateRegistrar.UnityEvent.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Fields]: #Fields
 [Grabbed]: #Grabbed
+[KinematicStateChangedOnGrabbed]: #KinematicStateChangedOnGrabbed
+[KinematicStateChangedOnUngrabbed]: #KinematicStateChangedOnUngrabbed
 [Ungrabbed]: #Ungrabbed
 [unsubscribeGrabActions]: #unsubscribeGrabActions
 [unsubscribeUngrabActions]: #unsubscribeUngrabActions
@@ -316,7 +371,9 @@ public virtual void UnregisterUngrabbed(InteractableFacade ungrabbable)
 [UnsubscribeOnDisable]: #UnsubscribeOnDisable
 [Methods]: #Methods
 [InteractableGrabbed(InteractableFacade)]: #InteractableGrabbedInteractableFacade
+[InteractableGrabbedKinematicChange(InteractableFacade)]: #InteractableGrabbedKinematicChangeInteractableFacade
 [InteractableUngrabbed(InteractableFacade)]: #InteractableUngrabbedInteractableFacade
+[InteractableUngrabbedKinematicChange(InteractableFacade)]: #InteractableUngrabbedKinematicChangeInteractableFacade
 [OnDisable()]: #OnDisable
 [RegisterGrabbed(GameObject)]: #RegisterGrabbedGameObject
 [RegisterGrabbed(InteractableFacade)]: #RegisterGrabbedInteractableFacade

--- a/Documentation/API/Interactables/Grab/README.md
+++ b/Documentation/API/Interactables/Grab/README.md
@@ -6,6 +6,10 @@
 
 Sets up the Interactable Prefab grab settings based on the provided user settings.
 
+#### [GrabInteractableConfigurator.UnityEvent]
+
+Defines the event with the Rigidbody.
+
 #### [InteractableGrabDropRestrictor]
 
 Restricts the ability to drop a grabbed [InteractableFacade].
@@ -22,14 +26,20 @@ Defines the event with the specified [InteractableFacade].
 
 Registers listeners to the initial grab and final ungrab states of an [InteractableFacade] and emits the [InteractableFacade] as the event payload.
 
+#### [InteractableGrabStateRegistrar.RigidbodyUnityEvent]
+
+Defines the event with the specified Rigidbody.
+
 #### [InteractableGrabStateRegistrar.UnityEvent]
 
 Defines the event with the specified [InteractableFacade].
 
 [GrabInteractableConfigurator]: GrabInteractableConfigurator.md
+[GrabInteractableConfigurator.UnityEvent]: GrabInteractableConfigurator.UnityEvent.md
 [InteractableGrabDropRestrictor]: InteractableGrabDropRestrictor.md
 [InteractableFacade]: ../../Interactables/InteractableFacade.md
 [InteractableGrabStateEmitter]: InteractableGrabStateEmitter.md
 [InteractableGrabStateEmitter.UnityEvent]: InteractableGrabStateEmitter.UnityEvent.md
 [InteractableGrabStateRegistrar]: InteractableGrabStateRegistrar.md
+[InteractableGrabStateRegistrar.RigidbodyUnityEvent]: InteractableGrabStateRegistrar.RigidbodyUnityEvent.md
 [InteractableGrabStateRegistrar.UnityEvent]: InteractableGrabStateRegistrar.UnityEvent.md

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
@@ -486,6 +486,7 @@
             }
 
             interactor.TouchConfiguration.TouchTracker.PrepareKinematicStateChange(GrabSetup.Facade.Configuration.ConsumerRigidbody);
+            GrabSetup.KinematicStateToChange?.Invoke(GrabSetup.Facade.Configuration.ConsumerRigidbody);
         }
 
         /// <summary>

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
@@ -1,5 +1,6 @@
 ﻿namespace Tilia.Interactions.Interactables.Interactables.Grab
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Tilia.Interactions.Interactables.Interactables.Grab.Action;
@@ -7,6 +8,7 @@
     using Tilia.Interactions.Interactables.Interactables.Grab.Receiver;
     using Tilia.Interactions.Interactables.Interactors;
     using UnityEngine;
+    using UnityEngine.Events;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Collection.List;
     using Zinnia.Extension;
@@ -16,6 +18,12 @@
     /// </summary>
     public class GrabInteractableConfigurator : MonoBehaviour
     {
+        /// <summary>
+        /// Defines the event with the <see cref="Rigidbody"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<Rigidbody> { }
+
         #region Facade Settings
         [Header("Facade Settings")]
         [Tooltip("The public interface facade.")]
@@ -166,6 +174,11 @@
                 actionTypes = value;
             }
         }
+        #endregion
+
+        #region Events
+        [Header("Events")]
+        public UnityEvent KinematicStateToChange = new UnityEvent();
         #endregion
 
         /// <summary>

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabStateRegistrar.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabStateRegistrar.cs
@@ -18,7 +18,13 @@
         /// </summary>
         [Serializable]
         public class UnityEvent : UnityEvent<InteractableFacade> { }
+        /// <summary>
+        /// Defines the event with the specified <see cref="Rigidbody"/>.
+        /// </summary>
+        [Serializable]
+        public class RigidbodyUnityEvent : UnityEvent<Rigidbody> { }
 
+        [Header("Subscription Settings")]
         [Tooltip("Determines whether to unsubscribe all registered listeners when the component is disabled.")]
         [SerializeField]
         private bool unsubscribeOnDisable = true;
@@ -37,6 +43,7 @@
             }
         }
 
+        [Header("Interactable Events")]
         /// <summary>
         /// Emitted when the <see cref="InteractableFacade"/> is grabbed.
         /// </summary>
@@ -45,6 +52,16 @@
         /// Emitted when the <see cref="InteractableFacade"/> is ungrabbed.
         /// </summary>
         public UnityEvent Ungrabbed = new UnityEvent();
+
+        [Header("Advanced Events")]
+        /// <summary>
+        /// Emitted when the <see cref="InteractableFacade"/> is about to change the kinematic state of its <see cref="Rigidbody"/> when grabbed.
+        /// </summary>
+        public RigidbodyUnityEvent KinematicStateChangedOnGrabbed = new RigidbodyUnityEvent();
+        /// <summary>
+        /// Emitted when the <see cref="InteractableFacade"/> is about to change the kinematic state of its <see cref="Rigidbody"/> when ungrabbed.
+        /// </summary>
+        public RigidbodyUnityEvent KinematicStateChangedOnUngrabbed = new RigidbodyUnityEvent();
 
         /// <summary>
         /// Actions that unsubscribe the added grab event listeners.
@@ -66,9 +83,19 @@
                 return;
             }
 
+            GrabInteractableConfigurator grabConfig = ungrabbable.Configuration.GrabConfiguration;
+
             void OnUngrabbed(InteractorFacade _) => InteractableUngrabbed(ungrabbable);
+            void OnUngrabbedKinematicChange(Rigidbody _) => InteractableUngrabbedKinematicChange(ungrabbable);
+
             ungrabbable.LastUngrabbed.AddListener(OnUngrabbed);
-            unsubscribeUngrabActions[ungrabbable] = () => ungrabbable.LastUngrabbed.RemoveListener(OnUngrabbed);
+            grabConfig.KinematicStateToChange.AddListener(OnUngrabbedKinematicChange);
+
+            unsubscribeUngrabActions[ungrabbable] = () =>
+            {
+                ungrabbable.LastUngrabbed.RemoveListener(OnUngrabbed);
+                grabConfig.KinematicStateToChange.RemoveListener(OnUngrabbedKinematicChange);
+            };
         }
 
         /// <summary>
@@ -96,9 +123,18 @@
                 return;
             }
 
+            GrabInteractableConfigurator grabConfig = grabbable.Configuration.GrabConfiguration;
+
             void OnGrabbed(InteractorFacade _) => InteractableGrabbed(grabbable);
+            void OnGrabbedKinematicChange(Rigidbody _) => InteractableGrabbedKinematicChange(grabbable);
+
             grabbable.FirstGrabbed.AddListener(OnGrabbed);
-            unsubscribeGrabActions[grabbable] = () => grabbable.FirstGrabbed.RemoveListener(OnGrabbed);
+            grabConfig.KinematicStateToChange.AddListener(OnGrabbedKinematicChange);
+            unsubscribeGrabActions[grabbable] = () =>
+            {
+                grabbable.FirstGrabbed.RemoveListener(OnGrabbed);
+                grabConfig.KinematicStateToChange.RemoveListener(OnGrabbedKinematicChange);
+            };
         }
 
         /// <summary>
@@ -230,6 +266,24 @@
         protected virtual void InteractableUngrabbed(InteractableFacade interactable)
         {
             Ungrabbed?.Invoke(interactable);
+        }
+
+        /// <summary>
+        /// Processes the kinematic state change on the grabbed event on the given Interactable.
+        /// </summary>
+        /// <param name="interactable">The Interactable to process the grab event for.</param>
+        protected virtual void InteractableGrabbedKinematicChange(InteractableFacade interactable)
+        {
+            KinematicStateChangedOnGrabbed?.Invoke(interactable.Configuration.ConsumerRigidbody);
+        }
+
+        /// <summary>
+        /// Processes the kinematic state change on the ungrabbed event on the given Interactable.
+        /// </summary>
+        /// <param name="interactable">The Interactable to process the grab event for.</param>
+        protected virtual void InteractableUngrabbedKinematicChange(InteractableFacade interactable)
+        {
+            KinematicStateChangedOnUngrabbed?.Invoke(interactable.Configuration.ConsumerRigidbody);
         }
     }
 }


### PR DESCRIPTION
Due to the changes in PhysX, the change of a Rigidbody kinematic
state will cause the collider to call the exit, then enter events
even though the collider has not stopped intersecting.

This was fixed in the Zinnia Collision Tracker and in turn the
Interactable and Interactor connection, but anywhere else that relies
on the interactable kinematic state will not have a clear point to
know when this happens.

So a new event has been added to the GrabInteractableConfigurator
that emits the rigidbody that the kinematic state is about to change
on.

Other dependents can now listen to this event to prepare any colliding
rigidbody for the impending exit/enter.

The GrabInteractableFollowAction emits this event when it changes the
kinematic state upon grab and ungrab.

The InteractableGrabStateRegistrar has also been updated to have two
new events that are connected to the kinematic state change on grab
and on ungrab, so they can be listened to when the grab or ungrab
occurs so any rigidbody can be prepared accordingly.