### PR TITLE
feat(Interactions): multiply velocity on interactor and interactable

### DIFF
--- a/Documentation/API/Interactables/Grab/Action/GrabInteractableFollowAction.md
+++ b/Documentation/API/Interactables/Grab/Action/GrabInteractableFollowAction.md
@@ -27,6 +27,7 @@ Describes an action that allows the Interactable to follow an Interactor's posit
   * [RotationModifiers]
   * [ScaleModifiers]
   * [VelocityApplier]
+  * [VelocityMultiplier]
   * [WillInheritIsKinematicWhenInactiveFromConsumerRigidbody]
 * [Methods]
   * [ApplyActiveKinematicState(GameObject)]
@@ -39,6 +40,8 @@ Describes an action that allows the Interactable to follow an Interactor's posit
   * [OnAfterGrabSetupChange()]
   * [OnEnable()]
   * [PrepareColliderForKinematicChange(GameObject)]
+  * [SetFollowTracking(Int32)]
+  * [SetGrabOffset(Int32)]
 
 ## Details
 
@@ -268,6 +271,16 @@ The Zinnia.Tracking.Velocity.VelocityApplier to apply velocity on ungrab.
 public VelocityApplier VelocityApplier { get; protected set; }
 ```
 
+#### VelocityMultiplier
+
+The Zinnia.Tracking.Velocity.VelocityMultiplier to multiply the applied velocity on ungrab.
+
+##### Declaration
+
+```
+public VelocityMultiplier VelocityMultiplier { get; protected set; }
+```
+
 #### WillInheritIsKinematicWhenInactiveFromConsumerRigidbody
 
 Whether the [IsKinematicWhenInactive] property inherits the kinematic state from GrabSetup.Facade.ConsumerRigidbody.isKinematic.
@@ -400,6 +413,38 @@ protected virtual void PrepareColliderForKinematicChange(GameObject initiator)
 | --- | --- | --- |
 | GameObject | initiator | The potential Interactor causing this state change. |
 
+#### SetFollowTracking(Int32)
+
+Sets the [FollowTracking].
+
+##### Declaration
+
+```
+public virtual void SetFollowTracking(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the [GrabInteractableFollowAction.TrackingType]. |
+
+#### SetGrabOffset(Int32)
+
+Sets the [GrabOffset].
+
+##### Declaration
+
+```
+public virtual void SetGrabOffset(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the [GrabInteractableFollowAction.OffsetType]. |
+
 [GrabInteractableAction]: GrabInteractableAction.md
 [GrabInteractableAction.InputActiveCollisionConsumer]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_InputActiveCollisionConsumer
 [GrabInteractableAction.InputGrabReceived]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_InputGrabReceived
@@ -410,9 +455,7 @@ protected virtual void PrepareColliderForKinematicChange(GameObject initiator)
 [GrabInteractableAction.NotifyGrab(GameObject)]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_NotifyGrab_GameObject_
 [GrabInteractableAction.NotifyUngrab(GameObject)]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_NotifyUngrab_GameObject_
 [Tilia.Interactions.Interactables.Interactables.Grab.Action]: README.md
-[GrabInteractableFollowAction.TrackingType]: GrabInteractableFollowAction.TrackingType.md
 [ObjectFollower]: GrabInteractableFollowAction.md#ObjectFollower
-[GrabInteractableFollowAction.OffsetType]: GrabInteractableFollowAction.OffsetType.md
 [IsKinematicWhenInactive]: GrabInteractableFollowAction.md#IsKinematicWhenInactive
 [FollowTracking]: GrabInteractableFollowAction.md#FollowTracking
 [GrabOffset]: GrabInteractableFollowAction.md#GrabOffset
@@ -420,6 +463,10 @@ protected virtual void PrepareColliderForKinematicChange(GameObject initiator)
 [GrabOffset]: GrabInteractableFollowAction.md#GrabOffset
 [GrabSetup]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_GrabSetup
 [GrabInteractableAction.OnAfterGrabSetupChange()]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_OnAfterGrabSetupChange
+[FollowTracking]: GrabInteractableFollowAction.md#FollowTracking
+[GrabInteractableFollowAction.TrackingType]: GrabInteractableFollowAction.TrackingType.md
+[GrabOffset]: GrabInteractableFollowAction.md#GrabOffset
+[GrabInteractableFollowAction.OffsetType]: GrabInteractableFollowAction.OffsetType.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -443,6 +490,7 @@ protected virtual void PrepareColliderForKinematicChange(GameObject initiator)
 [RotationModifiers]: #RotationModifiers
 [ScaleModifiers]: #ScaleModifiers
 [VelocityApplier]: #VelocityApplier
+[VelocityMultiplier]: #VelocityMultiplier
 [WillInheritIsKinematicWhenInactiveFromConsumerRigidbody]: #WillInheritIsKinematicWhenInactiveFromConsumerRigidbody
 [Methods]: #Methods
 [ApplyActiveKinematicState(GameObject)]: #ApplyActiveKinematicStateGameObject
@@ -455,3 +503,5 @@ protected virtual void PrepareColliderForKinematicChange(GameObject initiator)
 [OnAfterGrabSetupChange()]: #OnAfterGrabSetupChange
 [OnEnable()]: #OnEnable
 [PrepareColliderForKinematicChange(GameObject)]: #PrepareColliderForKinematicChangeGameObject
+[SetFollowTracking(Int32)]: #SetFollowTrackingInt32
+[SetGrabOffset(Int32)]: #SetGrabOffsetInt32

--- a/Documentation/API/Interactables/Grab/Receiver/GrabInteractableReceiver.md
+++ b/Documentation/API/Interactables/Grab/Receiver/GrabInteractableReceiver.md
@@ -25,6 +25,7 @@ Handles the way in which a grab event from an Interactor is received and process
   * [ConfigureGrabType()]
   * [OnAfterGrabTypeChange()]
   * [OnEnable()]
+  * [SetGrabType(Int32)]
 
 ## Details
 
@@ -211,9 +212,26 @@ protected virtual void OnAfterGrabTypeChange()
 protected virtual void OnEnable()
 ```
 
+#### SetGrabType(Int32)
+
+Sets the [GrabType].
+
+##### Declaration
+
+```
+public virtual void SetGrabType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the [GrabInteractableReceiver.ActiveType]. |
+
 [Tilia.Interactions.Interactables.Interactables.Grab.Receiver]: README.md
-[GrabInteractableReceiver.ActiveType]: GrabInteractableReceiver.ActiveType.md
 [GrabType]: GrabInteractableReceiver.md#GrabType
+[GrabType]: GrabInteractableReceiver.md#GrabType
+[GrabInteractableReceiver.ActiveType]: GrabInteractableReceiver.ActiveType.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -235,3 +253,4 @@ protected virtual void OnEnable()
 [ConfigureGrabType()]: #ConfigureGrabType
 [OnAfterGrabTypeChange()]: #OnAfterGrabTypeChange
 [OnEnable()]: #OnEnable
+[SetGrabType(Int32)]: #SetGrabTypeInt32

--- a/Documentation/API/Interactables/InteractableActionReceiverFacade.md
+++ b/Documentation/API/Interactables/InteractableActionReceiverFacade.md
@@ -23,6 +23,7 @@ The public interface into the Interactor Action Receiver Prefab.
   * [OnAfterTargetInteractableChange()]
   * [OnBeforeActivationStateChange()]
   * [OnBeforeTargetInteractableChange()]
+  * [SetActivationState(Int32)]
 
 ## Details
 
@@ -209,8 +210,23 @@ Called before [TargetInteractable] has been changed.
 protected virtual void OnBeforeTargetInteractableChange()
 ```
 
+#### SetActivationState(Int32)
+
+Sets the [ActivationState].
+
+##### Declaration
+
+```
+public virtual void SetActivationState(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the [InteractableActionReceiverFacade.InteractionState]. |
+
 [Tilia.Interactions.Interactables.Interactables]: README.md
-[InteractableActionReceiverFacade.InteractionState]: InteractableActionReceiverFacade.InteractionState.md
 [InteractableActionReceiverConfigurator]: InteractableActionReceiverConfigurator.md
 [InteractorActionPublisherFacade]: ../Interactors/InteractorActionPublisherFacade.md
 [InteractorActionPublisherFacadeObservableList]: ../Interactors/Collection/InteractorActionPublisherFacadeObservableList.md
@@ -222,6 +238,8 @@ protected virtual void OnBeforeTargetInteractableChange()
 [TargetInteractable]: InteractableActionReceiverFacade.md#TargetInteractable
 [ActivationState]: InteractableActionReceiverFacade.md#ActivationState
 [TargetInteractable]: InteractableActionReceiverFacade.md#TargetInteractable
+[ActivationState]: InteractableActionReceiverFacade.md#ActivationState
+[InteractableActionReceiverFacade.InteractionState]: InteractableActionReceiverFacade.InteractionState.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -241,3 +259,4 @@ protected virtual void OnBeforeTargetInteractableChange()
 [OnAfterTargetInteractableChange()]: #OnAfterTargetInteractableChange
 [OnBeforeActivationStateChange()]: #OnBeforeActivationStateChange
 [OnBeforeTargetInteractableChange()]: #OnBeforeTargetInteractableChange
+[SetActivationState(Int32)]: #SetActivationStateInt32

--- a/Documentation/API/Interactables/InteractableFacade.md
+++ b/Documentation/API/Interactables/InteractableFacade.md
@@ -65,6 +65,7 @@ The public interface into the Interactable Prefab.
   * [OnAfterGrabTypeChange()]
   * [OnAfterValidInteractionTypesChange()]
   * [OnEnable()]
+  * [SetGrabType(Int32)]
   * [SetValidInteractionTypes()]
   * [SnapFollowOrientation()]
   * [Ungrab(GameObject)]
@@ -764,6 +765,22 @@ protected virtual void OnAfterValidInteractionTypesChange()
 protected virtual void OnEnable()
 ```
 
+#### SetGrabType(Int32)
+
+Sets the [GrabType].
+
+##### Declaration
+
+```
+public virtual void SetGrabType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the [GrabInteractableReceiver.ActiveType]. |
+
 #### SetValidInteractionTypes()
 
 Activates or Deactivates the interaction types based on the selected [ValidInteractionTypes].
@@ -915,6 +932,7 @@ public virtual void UngrabAtEndOfFrame(InteractorFacade interactor)
 [GrabProviderIndex]: InteractableFacade.md#GrabProviderIndex
 [GrabType]: InteractableFacade.md#GrabType
 [ValidInteractionTypes]: InteractableFacade.md#ValidInteractionTypes
+[GrabType]: InteractableFacade.md#GrabType
 [ValidInteractionTypes]: InteractableFacade.md#ValidInteractionTypes
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -977,6 +995,7 @@ public virtual void UngrabAtEndOfFrame(InteractorFacade interactor)
 [OnAfterGrabTypeChange()]: #OnAfterGrabTypeChange
 [OnAfterValidInteractionTypesChange()]: #OnAfterValidInteractionTypesChange
 [OnEnable()]: #OnEnable
+[SetGrabType(Int32)]: #SetGrabTypeInt32
 [SetValidInteractionTypes()]: #SetValidInteractionTypes
 [SnapFollowOrientation()]: #SnapFollowOrientation
 [Ungrab(GameObject)]: #UngrabGameObject

--- a/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.Follow.prefab
+++ b/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.Follow.prefab
@@ -402,7 +402,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8af36ad896b0d6447b59cd26771491b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 2919631799667094827}
+  source: {fileID: 8125524646385854856}
   target: {fileID: 0}
 --- !u!1 &713341577594941567
 GameObject:
@@ -2837,6 +2837,7 @@ MonoBehaviour:
     xState: 0
     yState: 0
     zState: 0
+  inTargetSpace: 0
 --- !u!1 &5701689818747509894
 GameObject:
   m_ObjectHideFlags: 0
@@ -2846,6 +2847,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2857845961663347754}
+  - component: {fileID: 8125524646385854856}
   - component: {fileID: 3607323991379943426}
   m_Layer: 0
   m_Name: Interactable.GrabAction.Follow
@@ -2872,6 +2874,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8125524646385854856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5701689818747509894}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0253ce762a8da144bb6efe72d543f606, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 2919631799667094827}
+  velocityMultiplierFactor: {x: 1, y: 1, z: 1}
+  angularVelocityMultiplierFactor: {x: 1, y: 1, z: 1}
 --- !u!114 &3607323991379943426
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2905,6 +2922,7 @@ MonoBehaviour:
   followRotateAroundAngularVelocityModifier: {fileID: 7008387178892339823}
   forceSnapFollower: {fileID: 843673285366973432}
   velocityApplier: {fileID: 5458790361451553341}
+  velocityMultiplier: {fileID: 8125524646385854856}
   precisionLogicContainer: {fileID: 6356031491017706456}
   precisionCreateContainer: {fileID: 5901610279563605414}
   precisionForceCreateContainer: {fileID: 3724673846510280993}

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableFollowAction.cs
@@ -361,6 +361,24 @@
                 velocityApplier = value;
             }
         }
+        [Tooltip("The Zinnia.Tracking.Velocity.VelocityMultiplier to multiply the applied velocity on ungrab.")]
+        [SerializeField]
+        [Restricted]
+        private VelocityMultiplier velocityMultiplier;
+        /// <summary>
+        /// The <see cref="Zinnia.Tracking.Velocity.VelocityMultiplier"/> to multiply the applied velocity on ungrab.
+        /// </summary>
+        public VelocityMultiplier VelocityMultiplier
+        {
+            get
+            {
+                return velocityMultiplier;
+            }
+            protected set
+            {
+                velocityMultiplier = value;
+            }
+        }
         #endregion
 
         #region Grab Offset Settings
@@ -438,6 +456,24 @@
             }
         }
         #endregion
+
+        /// <summary>
+        /// Sets the <see cref="FollowTracking"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="TrackingType"/>.</param>
+        public virtual void SetFollowTracking(int index)
+        {
+            FollowTracking = EnumExtensions.GetByIndex<TrackingType>(index);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="GrabOffset"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="OffsetType"/>.</param>
+        public virtual void SetGrabOffset(int index)
+        {
+            GrabOffset = EnumExtensions.GetByIndex<OffsetType>(index);
+        }
 
         /// <summary>
         /// Applies the active kinematic state to the <see cref="Rigidbody"/> of the Interactable.

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Receiver/GrabInteractableReceiver.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Receiver/GrabInteractableReceiver.cs
@@ -278,6 +278,15 @@
         }
 
         /// <summary>
+        /// Sets the <see cref="GrabType"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="ActiveType"/>.</param>
+        public virtual void SetGrabType(int index)
+        {
+            GrabType = EnumExtensions.GetByIndex<ActiveType>(index);
+        }
+
+        /// <summary>
         /// Configures the Grab Type to be used.
         /// </summary>
         public virtual void ConfigureGrabType()

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableActionReceiverFacade.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableActionReceiverFacade.cs
@@ -159,6 +159,15 @@
         }
 
         /// <summary>
+        /// Sets the <see cref="ActivationState"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="InteractionState"/>.</param>
+        public virtual void SetActivationState(int index)
+        {
+            ActivationState = EnumExtensions.GetByIndex<InteractionState>(index);
+        }
+
+        /// <summary>
         /// Enables the given source <see cref="InteractorFacade"/> on the <see cref="ActionRegistrar"/>.
         /// </summary>
         /// <param name="source">The source to enable.</param>

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
@@ -239,6 +239,15 @@
         protected WaitForEndOfFrame delayInstruction = new WaitForEndOfFrame();
 
         /// <summary>
+        /// Sets the <see cref="GrabType"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="GrabInteractableReceiver.ActiveType"/>.</param>
+        public virtual void SetGrabType(int index)
+        {
+            GrabType = EnumExtensions.GetByIndex<GrabInteractableReceiver.ActiveType>(index);
+        }
+
+        /// <summary>
         /// Attempt to grab the Interactable to the given <see cref="GameObject"/> that contains an Interactor and ungrabs any existing grabbed Interactable.
         /// </summary>
         /// <param name="interactor">The GameObject that the Interactor is on.</param>

--- a/Runtime/Interactors/Prefabs/Interactions.Interactor.prefab
+++ b/Runtime/Interactors/Prefabs/Interactions.Interactor.prefab
@@ -192,6 +192,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5475526938935984466}
   - component: {fileID: 5839046843648530548}
+  - component: {fileID: 6986367063924956428}
   - component: {fileID: 8276754598564363198}
   - component: {fileID: 8735317141649716525}
   - component: {fileID: 5661210283589339750}
@@ -250,6 +251,21 @@ MonoBehaviour:
   avatarContainer: {fileID: 4211991488241996082}
   touchConfiguration: {fileID: 575120022572046411}
   grabConfiguration: {fileID: 1190284288443484346}
+--- !u!114 &6986367063924956428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3863422424652264037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0253ce762a8da144bb6efe72d543f606, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 8523271565689214913}
+  velocityMultiplierFactor: {x: 1, y: 1, z: 1}
+  angularVelocityMultiplierFactor: {x: 1, y: 1, z: 1}
 --- !u!54 &8276754598564363198
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -508,6 +524,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 389d7bfb100b39146a67ccaf229a6311, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8523271565689214913 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6459345143972930736, guid: 2cbd94cbb01df384eb07028e0f09c402,
+    type: 3}
+  m_PrefabInstance: {fileID: 3453287278815834993}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60829535893427a45be5af6abd9f0426, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &3663147785276308700 stripped


### PR DESCRIPTION
The Interactor and Interactable now has a VelocityMultiplier on them
so the throw velocity can be multiplied on either the Interactor
or the Interactable (or both).

The Interactable Editor has also been tidied up a bit with some
horizontal lines added and a bit more indentation to make it easier
to follow the flow of data.

A number of enum properties have also had set methods added for them
as well.