### PR TITLE
feat(Action): allow null grab action to force grab/ungrab events

### DIFF
--- a/Documentation/API/Interactables/Grab/Action/GrabInteractableNullAction.md
+++ b/Documentation/API/Interactables/Grab/Action/GrabInteractableNullAction.md
@@ -2,6 +2,21 @@
 
 Describes an action that performs no action.
 
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [ForceEmitEvents]
+  * [GrabEventContainer]
+  * [UngrabEventContainer]
+* [Methods]
+  * [OnEnable()]
+  * [OnForceEmitEventsChange()]
+
+## Details
+
 ##### Inheritance
 
 * System.Object
@@ -28,12 +43,66 @@ Describes an action that performs no action.
 
 [GrabInteractableAction.OnAfterGrabSetupChange()]
 
-###### **Namespace**: [Tilia.Interactions.Interactables.Interactables.Grab.Action]
+##### Namespace
+
+* [Tilia.Interactions.Interactables.Interactables.Grab.Action]
 
 ##### Syntax
 
 ```
 public class GrabInteractableNullAction : GrabInteractableAction
+```
+
+### Properties
+
+#### ForceEmitEvents
+
+Determines whether to force the grabbed/ungrabbed events even though no grab is occurring.
+
+##### Declaration
+
+```
+public bool ForceEmitEvents { get; set; }
+```
+
+#### GrabEventContainer
+
+The container of the grab event logic.
+
+##### Declaration
+
+```
+public GameObject GrabEventContainer { get; protected set; }
+```
+
+#### UngrabEventContainer
+
+The container of the ungrab event logic.
+
+##### Declaration
+
+```
+public GameObject UngrabEventContainer { get; protected set; }
+```
+
+### Methods
+
+#### OnEnable()
+
+##### Declaration
+
+```
+protected virtual void OnEnable()
+```
+
+#### OnForceEmitEventsChange()
+
+Called after [ForceEmitEvents] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnForceEmitEventsChange()
 ```
 
 [GrabInteractableAction]: GrabInteractableAction.md
@@ -47,3 +116,14 @@ public class GrabInteractableNullAction : GrabInteractableAction
 [GrabInteractableAction.NotifyUngrab(GameObject)]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_NotifyUngrab_GameObject_
 [GrabInteractableAction.OnAfterGrabSetupChange()]: GrabInteractableAction.md#Tilia_Interactions_Interactables_Interactables_Grab_Action_GrabInteractableAction_OnAfterGrabSetupChange
 [Tilia.Interactions.Interactables.Interactables.Grab.Action]: README.md
+[ForceEmitEvents]: GrabInteractableNullAction.md#ForceEmitEvents
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[ForceEmitEvents]: #ForceEmitEvents
+[GrabEventContainer]: #GrabEventContainer
+[UngrabEventContainer]: #UngrabEventContainer
+[Methods]: #Methods
+[OnEnable()]: #OnEnable
+[OnForceEmitEventsChange()]: #OnForceEmitEventsChange

--- a/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.None.prefab
+++ b/Runtime/Interactables/SharedResources/NestedPrefabs/GrabActions/Interactable.GrabAction.None.prefab
@@ -27,7 +27,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 9134324921452794517}
   m_Father: {fileID: 2051391533690766935}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -46,9 +47,18 @@ MonoBehaviour:
   payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_Calls:
+      - m_Target: {fileID: 7925925192945488712}
+        m_MethodName: Receive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   receiveValidity:
     field: {fileID: 0}
 --- !u!1 &2483680836169076513
@@ -98,8 +108,6 @@ MonoBehaviour:
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
 --- !u!1 &2708583508217938769
@@ -151,6 +159,69 @@ MonoBehaviour:
   inputUngrabReceived: {fileID: 1262342021308455835}
   inputGrabSetup: {fileID: 6250789347194366650}
   inputUngrabReset: {fileID: 1541688976099722520}
+  grabEventContainer: {fileID: 5180413231342961462}
+  ungrabEventContainer: {fileID: 2825662273729039477}
+  forceEmitEvents: 0
+--- !u!1 &2825662273729039477
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6702470895088415404}
+  - component: {fileID: 4652614541774835440}
+  m_Layer: 0
+  m_Name: UngrabEventEmitter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6702470895088415404
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2825662273729039477}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6900953668267260426}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4652614541774835440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2825662273729039477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  payload: {fileID: 0}
+  Emitted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2585577160392280173}
+        m_MethodName: NotifyUngrab
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  receiveValidity:
+    field: {fileID: 0}
 --- !u!1 &4024087777271173370
 GameObject:
   m_ObjectHideFlags: 0
@@ -233,8 +304,66 @@ MonoBehaviour:
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  receiveValidity:
+    field: {fileID: 0}
+--- !u!1 &5180413231342961462
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9134324921452794517}
+  - component: {fileID: 7925925192945488712}
+  m_Layer: 0
+  m_Name: GrabEventEmitter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9134324921452794517
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5180413231342961462}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1191039405875721317}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7925925192945488712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5180413231342961462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83b0262053634c7419fe6bb7a304c7b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  payload: {fileID: 0}
+  Emitted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2585577160392280173}
+        m_MethodName: NotifyGrab
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   receiveValidity:
     field: {fileID: 0}
 --- !u!1 &6357140107369392195
@@ -290,10 +419,9 @@ MonoBehaviour:
   Emitted:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Collision.Active.Event.Proxy.ActiveCollisionConsumerEventProxyEmitter+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
+  ruleSource: 0
 --- !u!1 &8232976407842504605
 GameObject:
   m_ObjectHideFlags: 0
@@ -321,7 +449,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 6702470895088415404}
   m_Father: {fileID: 2051391533690766935}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -340,8 +469,17 @@ MonoBehaviour:
   payload: {fileID: 0}
   Emitted:
     m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Event.Proxy.GameObjectEventProxyEmitter+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_Calls:
+      - m_Target: {fileID: 4652614541774835440}
+        m_MethodName: Receive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   receiveValidity:
     field: {fileID: 0}

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableNullAction.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/Action/GrabInteractableNullAction.cs
@@ -1,7 +1,79 @@
 ﻿namespace Tilia.Interactions.Interactables.Interactables.Grab.Action
 {
+    using UnityEngine;
+    using Zinnia.Data.Attribute;
+
     /// <summary>
     /// Describes an action that performs no action.
     /// </summary>
-    public class GrabInteractableNullAction : GrabInteractableAction { }
+    public class GrabInteractableNullAction : GrabInteractableAction
+    {
+        [Tooltip("The container of the grab event logic.")]
+        [SerializeField]
+        [Restricted]
+        private GameObject grabEventContainer;
+        /// <summary>
+        /// The container of the grab event logic.
+        /// </summary>
+        public GameObject GrabEventContainer
+        {
+            get
+            {
+                return grabEventContainer;
+            }
+            protected set
+            {
+                grabEventContainer = value;
+            }
+        }
+        [Tooltip("The container of the ungrab event logic.")]
+        [SerializeField]
+        [Restricted]
+        private GameObject ungrabEventContainer;
+        /// <summary>
+        /// The container of the ungrab event logic.
+        /// </summary>
+        public GameObject UngrabEventContainer
+        {
+            get
+            {
+                return ungrabEventContainer;
+            }
+            protected set
+            {
+                ungrabEventContainer = value;
+            }
+        }
+        [Tooltip("Determines whether to force the grabbed/ungrabbed events even though no grab is occurring.")]
+        [SerializeField]
+        private bool forceEmitEvents;
+        /// <summary>
+        /// Determines whether to force the grabbed/ungrabbed events even though no grab is occurring.
+        /// </summary>
+        public bool ForceEmitEvents
+        {
+            get
+            {
+                return forceEmitEvents;
+            }
+            set
+            {
+                forceEmitEvents = value;
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            OnForceEmitEventsChange();
+        }
+
+        /// <summary>
+        /// Called after <see cref="ForceEmitEvents"/> has been changed.
+        /// </summary>
+        protected virtual void OnForceEmitEventsChange()
+        {
+            GrabEventContainer.SetActive(ForceEmitEvents);
+            UngrabEventContainer.SetActive(ForceEmitEvents);
+        }
+    }
 }

--- a/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/GrabInteractableConfigurator.cs
@@ -515,7 +515,13 @@
         /// <returns>Whether the primary grab is of type <see cref="GrabInteractableNullAction"/>.</returns>
         protected virtual bool PrimaryGrabIsNone(int interactorCount)
         {
-            return Facade.GrabbingInteractors.Count > interactorCount && PrimaryAction.GetType() == typeof(GrabInteractableNullAction);
+            bool validNullAction = false;
+            if (PrimaryAction.GetType() == typeof(GrabInteractableNullAction))
+            {
+                GrabInteractableNullAction checkAction = (GrabInteractableNullAction)PrimaryAction;
+                validNullAction = checkAction.ForceEmitEvents ? false : true;
+            }
+            return Facade.GrabbingInteractors.Count > interactorCount && validNullAction;
         }
 
         /// <summary>


### PR DESCRIPTION
The GrabInteractableNullAction did not emit any events when the grab or
ungrab action occurred, which was technically correct because nothing
has happened, but there may be occasions where you'd want the events
to occur. This change allows the null action to be set to force the
events if required, but by default it still doesn't force the events
so no breaking changes will occur.