### PR TITLE
fix(InteractableConfigurator): reset instantiated action orientation

### DIFF
--- a/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
@@ -436,6 +436,9 @@
             actionObject.name = actionObject.name.Replace("(Clone)", "(Generated)");
             actionObject.transform.SetParent(facade.Configuration.GrabConfiguration.ActionTypes.transform);
             actionObject.transform.SetSiblingIndex(siblingPosition);
+            actionObject.transform.localPosition = Vector3.zero;
+            actionObject.transform.localRotation = Quaternion.identity;
+            actionObject.transform.localScale = Vector3.zero;
 
             return actionObject.GetComponent<GrabInteractableAction>();
         }


### PR DESCRIPTION
When the interactable action is instantiated it was not having the position, rotation and scale reset so if the original converted object was not at the zero orientation then the action was being offset.

This fix ensures the position, rotation and scale is reset to the identity when the action is childed to the interactable.