### PR TITLE
fix(InteractableConfigurator): set action instantiation correctly

### DIFF
--- a/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
@@ -429,16 +429,18 @@
             GameObject toInstantiate = GrabConfiguration.ActionTypes.NonSubscribableElements[newActionType];
             GameObject actionObject = null;
 #if UNITY_EDITOR
-            actionObject = (GameObject)PrefabUtility.InstantiatePrefab(toInstantiate);
+            actionObject = Application.isPlaying ? Instantiate(toInstantiate) : (GameObject)PrefabUtility.InstantiatePrefab(toInstantiate, facade.Configuration.GrabConfiguration.ActionTypes.transform);
 #else
             actionObject = Instantiate(toInstantiate);
 #endif
-            actionObject.name = actionObject.name.Replace("(Clone)", "(Generated)");
+            actionObject.transform.position = facade.transform.position;
+            actionObject.transform.rotation = facade.transform.rotation;
+            actionObject.transform.SetGlobalScale(facade.transform.lossyScale);
             actionObject.transform.SetParent(facade.Configuration.GrabConfiguration.ActionTypes.transform);
+
+            actionObject.name = actionObject.name.Replace("(Clone)", "(Generated)");
             actionObject.transform.SetSiblingIndex(siblingPosition);
-            actionObject.transform.localPosition = Vector3.zero;
-            actionObject.transform.localRotation = Quaternion.identity;
-            actionObject.transform.localScale = Vector3.zero;
+
 
             return actionObject.GetComponent<GrabInteractableAction>();
         }


### PR DESCRIPTION
There was an issue when instantiating a new action it was not possible to update the position, rotation or scale of any child object in the action GameObject. This has now been fixed by making the action object match the world orientation/scale of the interactable facade so when it is childed it resets to the correct zero origin.

The Instantiate method is also always called if the app is playing and not the PrefabUtility method as this is only now used at edit time in the editor.