### PR TITLE
fix(Editor): replace missing icon in newer unity versions

### DIFF
--- a/Editor/Interactables/InteractableFacadeEditor.cs
+++ b/Editor/Interactables/InteractableFacadeEditor.cs
@@ -26,7 +26,7 @@
         private const string velocityMultiplierTitle = "Velocity Multiplier Settings";
         private const string advancedFollowTitle = "Advanced Follow Settings";
         private const string customFollowOption = "Custom";
-        private const string dropdownButtonHelperIcon = "d_UnityEditor.LookDevView";
+        private const string dropdownButtonHelperIcon = "animationvisibilitytoggleon";
         private const string dropdownButtonHelperText = "|View Action GameObject";
         private Vector2 dropdownButtonHelperSize = new Vector2(22f, 14f);
 


### PR DESCRIPTION
The icon was available in Unity 2018 but does not seem to be available in 2022 so it has been replaced with something that is similar and seems to be available in all current versions.