### PR TITLE
feat(Interactions): add IsVisible property to interactable

### DIFF
--- a/Documentation/API/Interactables/InteractableConfigurator.md
+++ b/Documentation/API/Interactables/InteractableConfigurator.md
@@ -7,6 +7,9 @@ Sets up the Interactable Prefab based on the provided user settings.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Fields]
+  * [meshColliderTriggerStates]
+  * [meshRendererEnabledStates]
 * [Properties]
   * [ActiveCollisions]
   * [CollisionNotifier]
@@ -15,7 +18,9 @@ Sets up the Interactable Prefab based on the provided user settings.
   * [DisallowedGrabInteractors]
   * [DisallowedTouchInteractors]
   * [Facade]
+  * [GrabActionTypesCount]
   * [GrabConfiguration]
+  * [IsVisible]
   * [MeshContainer]
   * [TouchConfiguration]
 * [Methods]
@@ -24,10 +29,23 @@ Sets up the Interactable Prefab based on the provided user settings.
   * [ClearDisallowedGrabInteractors()]
   * [ClearDisallowedTouchInteractors()]
   * [ConfigureContainer()]
+  * [CreateGrabAction(GrabInteractableAction, Int32, Int32)]
+  * [DisableCollidersAndRenderers()]
+  * [GetGrabActionTypeObject(Int32)]
+  * [GetGrabActionTypeObject(InteractableFactory.ActionType)]
+  * [GetPrimaryAction()]
+  * [GetSecondaryAction()]
+  * [IsGrabConfigurationSet()]
   * [OnAfterConsumerContainerChange()]
   * [OnAfterConsumerRigidbodyChange()]
   * [OnAfterDisallowedGrabInteractorsChange()]
   * [OnAfterDisallowedTouchInteractorsChange()]
+  * [RestoreCollidersAndRenderers()]
+  * [SetFollowAndControlDirectionPair()]
+  * [UpdatePrimaryAction(Int32)]
+  * [UpdatePrimaryAction(InteractableFactory.ActionType)]
+  * [UpdateSecondaryAction(Int32)]
+  * [UpdateSecondaryAction(InteractableFactory.ActionType)]
 
 ## Details
 
@@ -44,6 +62,28 @@ Sets up the Interactable Prefab based on the provided user settings.
 
 ```
 public class InteractableConfigurator : MonoBehaviour
+```
+
+### Fields
+
+#### meshColliderTriggerStates
+
+A collection of trigger states for the colliders held within the [MeshContainer].
+
+##### Declaration
+
+```
+protected Dictionary<Collider, bool> meshColliderTriggerStates
+```
+
+#### meshRendererEnabledStates
+
+A collection of enabled states for the renderers held within the [MeshContainer].
+
+##### Declaration
+
+```
+protected Dictionary<Renderer, bool> meshRendererEnabledStates
 ```
 
 ### Properties
@@ -118,6 +158,16 @@ The public interface facade.
 public InteractableFacade Facade { get; protected set; }
 ```
 
+#### GrabActionTypesCount
+
+The total number of available grab action types.
+
+##### Declaration
+
+```
+public virtual int GrabActionTypesCount { get; }
+```
+
 #### GrabConfiguration
 
 The linked Grab Internal Setup.
@@ -126,6 +176,16 @@ The linked Grab Internal Setup.
 
 ```
 public GrabInteractableConfigurator GrabConfiguration { get; protected set; }
+```
+
+#### IsVisible
+
+Whether the Interactable is visible or not.
+
+##### Declaration
+
+```
+public virtual bool IsVisible { get; set; }
 ```
 
 #### MeshContainer
@@ -200,6 +260,132 @@ Configures any container data to the sub setup components.
 protected virtual void ConfigureContainer()
 ```
 
+#### CreateGrabAction(GrabInteractableAction, Int32, Int32)
+
+Creates a grab action for the given type.
+
+##### Declaration
+
+```
+protected virtual GrabInteractableAction CreateGrabAction(GrabInteractableAction currentAction, int newActionType, int siblingPosition)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [GrabInteractableAction] | currentAction | The current action. |
+| System.Int32 | newActionType | The new action type to create. |
+| System.Int32 | siblingPosition | The position the action should take in the hierarcy. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [GrabInteractableAction] | The created Grab Action. |
+
+#### DisableCollidersAndRenderers()
+
+Hides all of the found Collider and Renderer components in the [MeshContainer] and saves their current state for later restore.
+
+##### Declaration
+
+```
+protected virtual void DisableCollidersAndRenderers()
+```
+
+#### GetGrabActionTypeObject(Int32)
+
+Gets the GameObject for the given Grab Action Type index.
+
+##### Declaration
+
+```
+public virtual GameObject GetGrabActionTypeObject(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index to attempt to get. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| GameObject | The found GameObject for the given index type. |
+
+#### GetGrabActionTypeObject(InteractableFactory.ActionType)
+
+Gets the GameObject for the given Grab [InteractableFactory.ActionType].
+
+##### Declaration
+
+```
+public virtual GameObject GetGrabActionTypeObject(InteractableFactory.ActionType type)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [InteractableFactory.ActionType] | type | The action type to attempt to get. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| GameObject | The GameObject for the given action type. |
+
+#### GetPrimaryAction()
+
+Gets the current grab configuration primary action.
+
+##### Declaration
+
+```
+public virtual GrabInteractableAction GetPrimaryAction()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [GrabInteractableAction] | The current primary action. |
+
+#### GetSecondaryAction()
+
+Gets the current grab configuration secondary action.
+
+##### Declaration
+
+```
+public virtual GrabInteractableAction GetSecondaryAction()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [GrabInteractableAction] | The current secondary action. |
+
+#### IsGrabConfigurationSet()
+
+Determines whether the grab configuration is set.
+
+##### Declaration
+
+```
+public virtual bool IsGrabConfigurationSet()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the grab configuration is set. |
+
 #### OnAfterConsumerContainerChange()
 
 Called after [ConsumerContainer] has been changed.
@@ -240,7 +426,117 @@ Called after [DisallowedTouchInteractors] has been changed.
 protected virtual void OnAfterDisallowedTouchInteractorsChange()
 ```
 
+#### RestoreCollidersAndRenderers()
+
+Restores all of the current saved states for the found Collider and Renderer components found in the [MeshContainer].
+
+##### Declaration
+
+```
+protected virtual void RestoreCollidersAndRenderers()
+```
+
+#### SetFollowAndControlDirectionPair()
+
+Sets up the relevant linkages if the follow and control direction actions are selected in a pairing.
+
+##### Declaration
+
+```
+protected virtual void SetFollowAndControlDirectionPair()
+```
+
+#### UpdatePrimaryAction(Int32)
+
+Updates the primary grab action to the given type index.
+
+##### Declaration
+
+```
+public virtual GrabInteractableAction UpdatePrimaryAction(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The grab action type index. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [GrabInteractableAction] | The new grab action. |
+
+#### UpdatePrimaryAction(InteractableFactory.ActionType)
+
+Updates the primary grab action to the given type.
+
+##### Declaration
+
+```
+public virtual GrabInteractableAction UpdatePrimaryAction(InteractableFactory.ActionType type)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [InteractableFactory.ActionType] | type | The grab action type. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [GrabInteractableAction] | The new grab action. |
+
+#### UpdateSecondaryAction(Int32)
+
+Updates the secondary grab action to the given type index.
+
+##### Declaration
+
+```
+public virtual GrabInteractableAction UpdateSecondaryAction(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The grab action type index. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [GrabInteractableAction] | The new grab action. |
+
+#### UpdateSecondaryAction(InteractableFactory.ActionType)
+
+Updates the secondary grab action to the given type.
+
+##### Declaration
+
+```
+public virtual GrabInteractableAction UpdateSecondaryAction(InteractableFactory.ActionType type)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [InteractableFactory.ActionType] | type | The grab action type. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [GrabInteractableAction] | The new grab action. |
+
 [Tilia.Interactions.Interactables.Interactables]: README.md
+[MeshContainer]: InteractableConfigurator.md#MeshContainer
+[MeshContainer]: InteractableConfigurator.md#MeshContainer
 [CollisionNotifier]: InteractableConfigurator.md#CollisionNotifier
 [InteractableFacade]: InteractableFacade.md
 [GrabInteractableConfigurator]: Grab/GrabInteractableConfigurator.md
@@ -249,13 +545,20 @@ protected virtual void OnAfterDisallowedTouchInteractorsChange()
 [ConsumerRigidbody]: InteractableConfigurator.md#ConsumerRigidbody
 [DisallowedGrabInteractors]: InteractableConfigurator.md#DisallowedGrabInteractors
 [DisallowedTouchInteractors]: InteractableConfigurator.md#DisallowedTouchInteractors
+[GrabInteractableAction]: Grab/Action/GrabInteractableAction.md
+[MeshContainer]: InteractableConfigurator.md#MeshContainer
+[InteractableFactory.ActionType]: Utility/InteractableFactory.ActionType.md
 [ConsumerContainer]: InteractableConfigurator.md#ConsumerContainer
 [ConsumerRigidbody]: InteractableConfigurator.md#ConsumerRigidbody
 [DisallowedGrabInteractors]: InteractableConfigurator.md#DisallowedGrabInteractors
 [DisallowedTouchInteractors]: InteractableConfigurator.md#DisallowedTouchInteractors
+[MeshContainer]: InteractableConfigurator.md#MeshContainer
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Fields]: #Fields
+[meshColliderTriggerStates]: #meshColliderTriggerStates
+[meshRendererEnabledStates]: #meshRendererEnabledStates
 [Properties]: #Properties
 [ActiveCollisions]: #ActiveCollisions
 [CollisionNotifier]: #CollisionNotifier
@@ -264,7 +567,9 @@ protected virtual void OnAfterDisallowedTouchInteractorsChange()
 [DisallowedGrabInteractors]: #DisallowedGrabInteractors
 [DisallowedTouchInteractors]: #DisallowedTouchInteractors
 [Facade]: #Facade
+[GrabActionTypesCount]: #GrabActionTypesCount
 [GrabConfiguration]: #GrabConfiguration
+[IsVisible]: #IsVisible
 [MeshContainer]: #MeshContainer
 [TouchConfiguration]: #TouchConfiguration
 [Methods]: #Methods
@@ -273,7 +578,20 @@ protected virtual void OnAfterDisallowedTouchInteractorsChange()
 [ClearDisallowedGrabInteractors()]: #ClearDisallowedGrabInteractors
 [ClearDisallowedTouchInteractors()]: #ClearDisallowedTouchInteractors
 [ConfigureContainer()]: #ConfigureContainer
+[CreateGrabAction(GrabInteractableAction, Int32, Int32)]: #CreateGrabActionGrabInteractableAction-Int32-Int32
+[DisableCollidersAndRenderers()]: #DisableCollidersAndRenderers
+[GetGrabActionTypeObject(Int32)]: #GetGrabActionTypeObjectInt32
+[GetGrabActionTypeObject(InteractableFactory.ActionType)]: #GetGrabActionTypeObjectInteractableFactory.ActionType
+[GetPrimaryAction()]: #GetPrimaryAction
+[GetSecondaryAction()]: #GetSecondaryAction
+[IsGrabConfigurationSet()]: #IsGrabConfigurationSet
 [OnAfterConsumerContainerChange()]: #OnAfterConsumerContainerChange
 [OnAfterConsumerRigidbodyChange()]: #OnAfterConsumerRigidbodyChange
 [OnAfterDisallowedGrabInteractorsChange()]: #OnAfterDisallowedGrabInteractorsChange
 [OnAfterDisallowedTouchInteractorsChange()]: #OnAfterDisallowedTouchInteractorsChange
+[RestoreCollidersAndRenderers()]: #RestoreCollidersAndRenderers
+[SetFollowAndControlDirectionPair()]: #SetFollowAndControlDirectionPair
+[UpdatePrimaryAction(Int32)]: #UpdatePrimaryActionInt32
+[UpdatePrimaryAction(InteractableFactory.ActionType)]: #UpdatePrimaryActionInteractableFactory.ActionType
+[UpdateSecondaryAction(Int32)]: #UpdateSecondaryActionInt32
+[UpdateSecondaryAction(InteractableFactory.ActionType)]: #UpdateSecondaryActionInteractableFactory.ActionType

--- a/Documentation/API/Interactables/InteractableFacade.md
+++ b/Documentation/API/Interactables/InteractableFacade.md
@@ -30,6 +30,7 @@ The public interface into the Interactable Prefab.
   * [IsGrabbed]
   * [IsGrabTypeToggle]
   * [IsTouched]
+  * [IsVisible]
   * [MeshContainer]
   * [Meshes]
   * [PrimaryGrabEnabled]
@@ -307,6 +308,16 @@ Whether the Interactable is currently being touched by any valid Interactor.
 
 ```
 public virtual bool IsTouched { get; }
+```
+
+#### IsVisible
+
+Whether the Interactable is visible or not. Collisions will still occur on a hidden Interactable but only against a trigger collider.
+
+##### Declaration
+
+```
+public virtual bool IsVisible { get; set; }
 ```
 
 #### MeshContainer
@@ -960,6 +971,7 @@ public virtual void UngrabAtEndOfFrame(InteractorFacade interactor)
 [IsGrabbed]: #IsGrabbed
 [IsGrabTypeToggle]: #IsGrabTypeToggle
 [IsTouched]: #IsTouched
+[IsVisible]: #IsVisible
 [MeshContainer]: #MeshContainer
 [Meshes]: #Meshes
 [PrimaryGrabEnabled]: #PrimaryGrabEnabled

--- a/Documentation/API/Interactables/Utility.meta
+++ b/Documentation/API/Interactables/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62556c98521d07342b9ee52f0bdd1378
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Interactables/Utility/InteractableCreator.md
+++ b/Documentation/API/Interactables/Utility/InteractableCreator.md
@@ -1,0 +1,111 @@
+# Class InteractableCreator
+
+A helper class to easily create an Interactable Object via script.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Fields]
+  * [interactableFactory]
+* [Properties]
+  * [InteractableObject]
+* [Methods]
+  * [Convert(GameObject)]
+  * [DoConvert(GameObject)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* InteractableCreator
+
+##### Namespace
+
+* [Tilia.Interactions.Interactables.Interactables.Utility]
+
+##### Syntax
+
+```
+public class InteractableCreator : MonoBehaviour
+```
+
+### Fields
+
+#### interactableFactory
+
+The factory for creating new Interactable Obejcts.
+
+##### Declaration
+
+```
+protected InteractableFactory interactableFactory
+```
+
+### Properties
+
+#### InteractableObject
+
+The interactable prefab.
+
+##### Declaration
+
+```
+public GameObject InteractableObject { get; protected set; }
+```
+
+### Methods
+
+#### Convert(GameObject)
+
+Converts a given GameObject and wraps it into an [InteractableFacade].
+
+##### Declaration
+
+```
+public virtual InteractableFacade Convert(GameObject objectToConvert)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | objectToConvert | The GameObject to convert. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [InteractableFacade] | The created Interactable Facade. |
+
+#### DoConvert(GameObject)
+
+Converts a given GameObject and wraps it into an [InteractableFacade].
+
+##### Declaration
+
+```
+public virtual void DoConvert(GameObject objectToConvert)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | objectToConvert | The GameObject to convert. |
+
+[Tilia.Interactions.Interactables.Interactables.Utility]: README.md
+[InteractableFactory]: InteractableFactory.md
+[InteractableFacade]: ../../Interactables/InteractableFacade.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Fields]: #Fields
+[interactableFactory]: #interactableFactory
+[Properties]: #Properties
+[InteractableObject]: #InteractableObject
+[Methods]: #Methods
+[Convert(GameObject)]: #ConvertGameObject
+[DoConvert(GameObject)]: #DoConvertGameObject

--- a/Documentation/API/Interactables/Utility/InteractableCreator.md.meta
+++ b/Documentation/API/Interactables/Utility/InteractableCreator.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ac64deff92edc624dad88c85ed262bc4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Interactables/Utility/InteractableFactory.ActionType.md
+++ b/Documentation/API/Interactables/Utility/InteractableFactory.ActionType.md
@@ -1,0 +1,38 @@
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Fields]
+
+## Details
+
+# Enum InteractableFactory.ActionType
+
+The grab action type to be applied to the primary or secondary action.
+
+##### Namespace
+
+* [Tilia.Interactions.Interactables.Interactables.Utility]
+
+##### Syntax
+
+```
+public enum ActionType
+```
+
+### Fields
+
+| Name | Description |
+| --- | --- |
+| ControlDirection | The Interactable will attempt to rotate into the direction of the Interactor. |
+| Follow | The Interactable will follow the Interactor. |
+| None | No action is performed. |
+| Scale | The Interactable will scale in size based on the point difference between the given Interactors. |
+| Swap | The Interactable will swap the primary action to the secondary Interactor. |
+
+[Tilia.Interactions.Interactables.Interactables.Utility]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Fields]: #Fields

--- a/Documentation/API/Interactables/Utility/InteractableFactory.ActionType.md.meta
+++ b/Documentation/API/Interactables/Utility/InteractableFactory.ActionType.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9d6285851c0537f4d8e2fae8ee905048
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Interactables/Utility/InteractableFactory.md
+++ b/Documentation/API/Interactables/Utility/InteractableFactory.md
@@ -1,0 +1,100 @@
+# Class InteractableFactory
+
+A factory for creating an Interactable Object.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Methods]
+  * [CanConvert(GameObject)]
+  * [Create(GameObject, GameObject)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* InteractableFactory
+
+##### Inherited Members
+
+System.Object.ToString()
+
+System.Object.Equals(System.Object)
+
+System.Object.Equals(System.Object, System.Object)
+
+System.Object.ReferenceEquals(System.Object, System.Object)
+
+System.Object.GetHashCode()
+
+System.Object.GetType()
+
+System.Object.MemberwiseClone()
+
+##### Namespace
+
+* [Tilia.Interactions.Interactables.Interactables.Utility]
+
+##### Syntax
+
+```
+public class InteractableFactory
+```
+
+### Methods
+
+#### CanConvert(GameObject)
+
+Whether the given GameObject can be converted to an Interactable Object.
+
+##### Declaration
+
+```
+public virtual bool CanConvert(GameObject objectToConvert)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | objectToConvert | The object to convert. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether it can be converted. |
+
+#### Create(GameObject, GameObject)
+
+Creates a new Interactable Object in the scene.
+
+##### Declaration
+
+```
+public virtual GameObject Create(GameObject interactablePrefab, GameObject objectToConvert)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | interactablePrefab | The Interactable Object prefab to create from. |
+| GameObject | objectToConvert | The Object to convert into the new Interactable Object. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| GameObject | The created Interactable Object. |
+
+[Tilia.Interactions.Interactables.Interactables.Utility]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Methods]: #Methods
+[CanConvert(GameObject)]: #CanConvertGameObject
+[Create(GameObject, GameObject)]: #CreateGameObject-GameObject

--- a/Documentation/API/Interactables/Utility/InteractableFactory.md.meta
+++ b/Documentation/API/Interactables/Utility/InteractableFactory.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a3d8cf71f66243f42b536dbecc0bd77f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Interactables/Utility/README.md
+++ b/Documentation/API/Interactables/Utility/README.md
@@ -1,0 +1,21 @@
+# Namespace Tilia.Interactions.Interactables.Interactables.Utility
+
+### Classes
+
+#### [InteractableCreator]
+
+A helper class to easily create an Interactable Object via script.
+
+#### [InteractableFactory]
+
+A factory for creating an Interactable Object.
+
+### Enums
+
+#### [InteractableFactory.ActionType]
+
+The grab action type to be applied to the primary or secondary action.
+
+[InteractableCreator]: InteractableCreator.md
+[InteractableFactory]: InteractableFactory.md
+[InteractableFactory.ActionType]: InteractableFactory.ActionType.md

--- a/Documentation/API/Interactables/Utility/README.md.meta
+++ b/Documentation/API/Interactables/Utility/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2df7dc00ccad23d43a3db02e5ec6a1a0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableFacade.cs
@@ -223,6 +223,20 @@
         /// Whether the secondary grab action functionality is enabled.
         /// </summary>
         public virtual bool SecondaryGrabEnabled => Configuration.GrabConfiguration.PrimaryAction.gameObject.activeInHierarchy;
+        /// <summary>
+        /// Whether the Interactable is visible or not. Collisions will still occur on a hidden Interactable but only against a trigger collider.
+        /// </summary>
+        public virtual bool IsVisible
+        {
+            get
+            {
+                return Configuration.IsVisible;
+            }
+            set
+            {
+                Configuration.IsVisible = value;
+            }
+        }
 
         /// <summary>
         /// The routine for grabbing after a certain instruction.


### PR DESCRIPTION
The IsVisible property on the getter will return whether the interactable object is in its `visible` state which is the renderers are active and the colliders working.

When the IsVisible property is set to `false` then all of the renderers are disabled and all of the colliders are set to trigger colliders to mimmic the GameObject becoming invisible but still active within the scene.