### PR TITLE
fix(Configurator): catch error on destroy nested prefabs

### DIFF
--- a/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/InteractableConfigurator.cs
@@ -1,5 +1,6 @@
 ﻿namespace Tilia.Interactions.Interactables.Interactables
 {
+    using System;
     using System.Collections.Generic;
     using Tilia.Interactions.Interactables.Interactables.Grab;
     using Tilia.Interactions.Interactables.Interactables.Grab.Action;
@@ -499,7 +500,16 @@
 
             if (currentAction != null)
             {
-                DestroyImmediate(currentAction.gameObject);
+                try
+                {
+                    //If the Unity version supports destroying the nested prefab then do that.
+                    DestroyImmediate(currentAction.gameObject);
+                }
+                catch (InvalidOperationException)
+                {
+                    //Otherwise just disable that GameObject.
+                    currentAction.gameObject.SetActive(false);
+                }
             }
 
             GameObject toInstantiate = GrabConfiguration.ActionTypes.NonSubscribableElements[newActionType];


### PR DESCRIPTION
Older versions of Unity cannot destroy a nested prefab, so as the Controllables for example nest the Interactable prefab, if the Interactable prefab is attempted to change the grab action then this tries to delete the nested grab action but will raise an InvalidOperationException because this nested prefab cannot be deleted.

The fix for this is to just disable the hard wired prefab and then create a new temporary prefab that can be continually updated.