### PR TITLE
feat(Prefabs): match rules to the grabbed interactable collider

### DIFF
--- a/Documentation/API/Interactables/Grab/Action/GrabInteractableFollowAction.md
+++ b/Documentation/API/Interactables/Grab/Action/GrabInteractableFollowAction.md
@@ -17,6 +17,7 @@ Describes an action that allows the Interactable to follow an Interactor's posit
   * [FollowTransformRotateOnPositionDifferenceModifier]
   * [ForceSnapFollower]
   * [GrabOffset]
+  * [InteractableRigidbody]
   * [IsKinematicWhenActive]
   * [IsKinematicWhenInactive]
   * [ObjectFollower]
@@ -179,6 +180,16 @@ The offset to apply when grabbing the Interactable.
 
 ```
 public GrabInteractableFollowAction.OffsetType GrabOffset { get; set; }
+```
+
+#### InteractableRigidbody
+
+The Rigidbody linked to the interactable.
+
+##### Declaration
+
+```
+public virtual Rigidbody InteractableRigidbody { get; }
 ```
 
 #### IsKinematicWhenActive
@@ -599,6 +610,7 @@ public virtual void UseRulesMatcherOrientationHandleLogic()
 [FollowTransformRotateOnPositionDifferenceModifier]: #FollowTransformRotateOnPositionDifferenceModifier
 [ForceSnapFollower]: #ForceSnapFollower
 [GrabOffset]: #GrabOffset
+[InteractableRigidbody]: #InteractableRigidbody
 [IsKinematicWhenActive]: #IsKinematicWhenActive
 [IsKinematicWhenInactive]: #IsKinematicWhenInactive
 [ObjectFollower]: #ObjectFollower

--- a/Documentation/API/Interactables/InteractableConfigurator.md
+++ b/Documentation/API/Interactables/InteractableConfigurator.md
@@ -14,6 +14,7 @@ Sets up the Interactable Prefab based on the provided user settings.
   * [meshRendererEnabledStates]
 * [Properties]
   * [ActiveCollisions]
+  * [AddCollisionExtractor]
   * [CollisionNotifier]
   * [ConsumerContainer]
   * [ConsumerRigidbody]
@@ -24,6 +25,7 @@ Sets up the Interactable Prefab based on the provided user settings.
   * [GrabConfiguration]
   * [IsVisible]
   * [MeshContainer]
+  * [RemoveCollisionExtractor]
   * [TouchConfiguration]
 * [Methods]
   * [ClearConsumerContainer()]
@@ -46,6 +48,7 @@ Sets up the Interactable Prefab based on the provided user settings.
   * [RestoreCollidersAndRenderers()]
   * [SetFollowAndControlDirectionPair()]
   * [SetFollowPrecisionPointToDirectionModifierPivot(GameObject)]
+  * [SetRigidbodyMaxAngularVelocity(Single)]
   * [UnsetFollowPrecisionPointToDirectionModifierPivot(GameObject)]
   * [UpdatePrimaryAction(Int32)]
   * [UpdatePrimaryAction(InteractableFactory.ActionType)]
@@ -120,7 +123,17 @@ The linked GameObjectObservableList.
 ##### Declaration
 
 ```
-public GameObjectObservableList ActiveCollisions { get; protected set; }
+public GameObjectObservableList ActiveCollisions { get; set; }
+```
+
+#### AddCollisionExtractor
+
+The linked NotifierContainerExtractor for adding collisions.
+
+##### Declaration
+
+```
+public NotifierContainerExtractor AddCollisionExtractor { get; set; }
 ```
 
 #### CollisionNotifier
@@ -130,7 +143,7 @@ The linked [CollisionNotifier].
 ##### Declaration
 
 ```
-public CollisionNotifier CollisionNotifier { get; protected set; }
+public CollisionNotifier CollisionNotifier { get; set; }
 ```
 
 #### ConsumerContainer
@@ -180,7 +193,7 @@ The public interface facade.
 ##### Declaration
 
 ```
-public InteractableFacade Facade { get; protected set; }
+public InteractableFacade Facade { get; set; }
 ```
 
 #### GrabActionTypesCount
@@ -200,7 +213,7 @@ The linked Grab Internal Setup.
 ##### Declaration
 
 ```
-public GrabInteractableConfigurator GrabConfiguration { get; protected set; }
+public GrabInteractableConfigurator GrabConfiguration { get; set; }
 ```
 
 #### IsVisible
@@ -220,7 +233,17 @@ The GameObject that contains the mesh for the Interactable.
 ##### Declaration
 
 ```
-public GameObject MeshContainer { get; protected set; }
+public GameObject MeshContainer { get; set; }
+```
+
+#### RemoveCollisionExtractor
+
+The linked NotifierContainerExtractor for removing collisions.
+
+##### Declaration
+
+```
+public NotifierContainerExtractor RemoveCollisionExtractor { get; set; }
 ```
 
 #### TouchConfiguration
@@ -230,7 +253,7 @@ The linked Touch Internal Setup.
 ##### Declaration
 
 ```
-public TouchInteractableConfigurator TouchConfiguration { get; protected set; }
+public TouchInteractableConfigurator TouchConfiguration { get; set; }
 ```
 
 ### Methods
@@ -495,6 +518,22 @@ protected virtual void SetFollowPrecisionPointToDirectionModifierPivot(GameObjec
 | --- | --- | --- |
 | GameObject | precisionPointContainer | The precision point container. |
 
+#### SetRigidbodyMaxAngularVelocity(Single)
+
+Sets the Maximum Angular Velocity of the Rigidbody in radians per seconds.
+
+##### Declaration
+
+```
+public virtual void SetRigidbodyMaxAngularVelocity(float angularVelocity)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | angularVelocity | The maximum angular velocity in radians per seconds. |
+
 #### UnsetFollowPrecisionPointToDirectionModifierPivot(GameObject)
 
 Unsets the set up done in the [SetFollowPrecisionPointToDirectionModifierPivot(GameObject)] method.
@@ -631,6 +670,7 @@ public virtual GrabInteractableAction UpdateSecondaryAction(InteractableFactory.
 [meshRendererEnabledStates]: #meshRendererEnabledStates
 [Properties]: #Properties
 [ActiveCollisions]: #ActiveCollisions
+[AddCollisionExtractor]: #AddCollisionExtractor
 [CollisionNotifier]: #CollisionNotifier
 [ConsumerContainer]: #ConsumerContainer
 [ConsumerRigidbody]: #ConsumerRigidbody
@@ -641,6 +681,7 @@ public virtual GrabInteractableAction UpdateSecondaryAction(InteractableFactory.
 [GrabConfiguration]: #GrabConfiguration
 [IsVisible]: #IsVisible
 [MeshContainer]: #MeshContainer
+[RemoveCollisionExtractor]: #RemoveCollisionExtractor
 [TouchConfiguration]: #TouchConfiguration
 [Methods]: #Methods
 [ClearConsumerContainer()]: #ClearConsumerContainer
@@ -663,6 +704,7 @@ public virtual GrabInteractableAction UpdateSecondaryAction(InteractableFactory.
 [RestoreCollidersAndRenderers()]: #RestoreCollidersAndRenderers
 [SetFollowAndControlDirectionPair()]: #SetFollowAndControlDirectionPair
 [SetFollowPrecisionPointToDirectionModifierPivot(GameObject)]: #SetFollowPrecisionPointToDirectionModifierPivotGameObject
+[SetRigidbodyMaxAngularVelocity(Single)]: #SetRigidbodyMaxAngularVelocitySingle
 [UnsetFollowPrecisionPointToDirectionModifierPivot(GameObject)]: #UnsetFollowPrecisionPointToDirectionModifierPivotGameObject
 [UpdatePrimaryAction(Int32)]: #UpdatePrimaryActionInt32
 [UpdatePrimaryAction(InteractableFactory.ActionType)]: #UpdatePrimaryActionInteractableFactory.ActionType

--- a/Documentation/API/Interactables/InteractableFacade.md
+++ b/Documentation/API/Interactables/InteractableFacade.md
@@ -239,7 +239,7 @@ The linked [InteractableConfigurator].
 ##### Declaration
 
 ```
-public InteractableConfigurator Configuration { get; protected set; }
+public InteractableConfigurator Configuration { get; set; }
 ```
 
 #### GrabbingInteractors

--- a/Documentation/API/Interactables/Utility/InteractableCreator.md
+++ b/Documentation/API/Interactables/Utility/InteractableCreator.md
@@ -14,6 +14,8 @@ A helper class to easily create an Interactable Object via script.
 * [Methods]
   * [Convert(GameObject)]
   * [DoConvert(GameObject)]
+  * [DoEmbed(GameObject)]
+  * [Embed(GameObject)]
 
 ## Details
 
@@ -96,6 +98,44 @@ public virtual void DoConvert(GameObject objectToConvert)
 | --- | --- | --- |
 | GameObject | objectToConvert | The GameObject to convert. |
 
+#### DoEmbed(GameObject)
+
+Embeds a created [InteractableFacade] into the given GameObject.
+
+##### Declaration
+
+```
+public virtual void DoEmbed(GameObject embedObject)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | embedObject | The GameObject to embed the Interactable within. |
+
+#### Embed(GameObject)
+
+Embeds a created [InteractableFacade] into the given GameObject.
+
+##### Declaration
+
+```
+public virtual InteractableFacade Embed(GameObject embedObject)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | embedObject | The GameObject to embed the Interactable within. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| [InteractableFacade] | The created Interactable Facade. |
+
 [Tilia.Interactions.Interactables.Interactables.Utility]: README.md
 [InteractableFactory]: InteractableFactory.md
 [InteractableFacade]: ../../Interactables/InteractableFacade.md
@@ -109,3 +149,5 @@ public virtual void DoConvert(GameObject objectToConvert)
 [Methods]: #Methods
 [Convert(GameObject)]: #ConvertGameObject
 [DoConvert(GameObject)]: #DoConvertGameObject
+[DoEmbed(GameObject)]: #DoEmbedGameObject
+[Embed(GameObject)]: #EmbedGameObject

--- a/Documentation/API/Interactables/Utility/InteractableFactory.md
+++ b/Documentation/API/Interactables/Utility/InteractableFactory.md
@@ -10,6 +10,8 @@ A factory for creating an Interactable Object.
 * [Methods]
   * [CanConvert(GameObject)]
   * [Create(GameObject, GameObject)]
+  * [Embed(GameObject, GameObject)]
+  * [HideMeshes(GameObject)]
 
 ## Details
 
@@ -91,6 +93,45 @@ public virtual GameObject Create(GameObject interactablePrefab, GameObject objec
 | --- | --- |
 | GameObject | The created Interactable Object. |
 
+#### Embed(GameObject, GameObject)
+
+Embeds an Interactable Object as a child of the existing scene GameObject.
+
+##### Declaration
+
+```
+public virtual GameObject Embed(GameObject interactablePrefab, GameObject embedInto)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | interactablePrefab | The Interactable Object prefab to create from and embed. |
+| GameObject | embedInto | n/a |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| GameObject | The existing scene GameObject with the embedded newly created Interactable Object. |
+
+#### HideMeshes(GameObject)
+
+Hides all of the meshes found in the given GameObject child hierarchy.
+
+##### Declaration
+
+```
+protected virtual void HideMeshes(GameObject container)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | container | The container to find the meshes in. |
+
 [Tilia.Interactions.Interactables.Interactables.Utility]: README.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -98,3 +139,5 @@ public virtual GameObject Create(GameObject interactablePrefab, GameObject objec
 [Methods]: #Methods
 [CanConvert(GameObject)]: #CanConvertGameObject
 [Create(GameObject, GameObject)]: #CreateGameObject-GameObject
+[Embed(GameObject, GameObject)]: #EmbedGameObject-GameObject
+[HideMeshes(GameObject)]: #HideMeshesGameObject

--- a/Runtime/Interactables/Prefabs/Interactions.Interactable.prefab
+++ b/Runtime/Interactables/Prefabs/Interactions.Interactable.prefab
@@ -1,5 +1,50 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1333959529814944526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 932574462019479185}
+  - component: {fileID: 8433133876822289734}
+  m_Layer: 0
+  m_Name: GrabbedColliderMatcher
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &932574462019479185
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333959529814944526}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4125844836897333167}
+  m_Father: {fileID: 4468803095658734627}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8433133876822289734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333959529814944526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed4d8b391dc78854da24cb25b16ae490, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  elements: {fileID: 1289093139631889599}
 --- !u!1 &1417232386877869616
 GameObject:
   m_ObjectHideFlags: 0
@@ -177,6 +222,7 @@ Transform:
   - {fileID: 8645910841389205952}
   - {fileID: 785192508888914263}
   - {fileID: 8947053477063701665}
+  - {fileID: 932574462019479185}
   m_Father: {fileID: 8090891674275893548}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -234,6 +280,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1464503561220189846}
   - {fileID: 4449573522652691551}
   - {fileID: 5698457419927422820}
   - {fileID: 6651591756605911726}
@@ -294,7 +341,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8947053477063701665}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8860187548095682544
 MonoBehaviour:
@@ -342,6 +389,78 @@ MonoBehaviour:
   - {fileID: 5976216758737313083, guid: e31ddf5ca7950534fb66684149b566b0, type: 3}
   - {fileID: 2976029423634337508, guid: ddf9e23c4e73d624bb91f34430b5cd60, type: 3}
   - {fileID: 3947244001677853409, guid: cdc2cc72af5e4b44194f8fd19e6a2def, type: 3}
+--- !u!1 &7425842043936401638
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4125844836897333167}
+  - component: {fileID: 1289093139631889599}
+  m_Layer: 0
+  m_Name: RulesMatcherList
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4125844836897333167
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7425842043936401638}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 932574462019479185}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1289093139631889599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7425842043936401638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 170d7cd8ade42fc48b934dd3527bc7fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements: []
 --- !u!1 &7774344186399642229
 GameObject:
   m_ObjectHideFlags: 0
@@ -508,6 +627,176 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58d6cb68905534b4d8baf13b96b36cd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &8163499577323768443
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3648680824756595854}
+  - component: {fileID: 4413942943006763003}
+  - component: {fileID: 4427309043035021434}
+  m_Layer: 0
+  m_Name: GetGrabbedColliderGameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3648680824756595854
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8163499577323768443}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1464503561220189846}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4413942943006763003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8163499577323768443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e4ab0cf093fe7743a5f475de9e52876, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Extracted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4427309043035021434}
+        m_MethodName: DoExtract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+  source:
+    publisher:
+      sourceContainer: {fileID: 0}
+    currentCollision:
+      forwardSource: {fileID: 0}
+      isTrigger: 0
+      colliderData: {fileID: 0}
+--- !u!114 &4427309043035021434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8163499577323768443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ba768ecdd7b4b2e99b76e6ee4960c23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Extracted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8433133876822289734}
+        m_MethodName: Match
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+  source:
+    forwardSource: {fileID: 0}
+    isTrigger: 0
+    colliderData: {fileID: 0}
+  extractCompoundParent: 0
+--- !u!1 &8659899451832879542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1464503561220189846}
+  - component: {fileID: 8673786206831570023}
+  m_Layer: 0
+  m_Name: PreGrabLogic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1464503561220189846
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8659899451832879542}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3648680824756595854}
+  m_Father: {fileID: 8947053477063701665}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8673786206831570023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8659899451832879542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb209bebc91e714ba9375ca64ebc454, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  payload:
+    publisher:
+      sourceContainer: {fileID: 0}
+    currentCollision:
+      forwardSource: {fileID: 0}
+      isTrigger: 0
+      colliderData: {fileID: 0}
+  Emitted:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4413942943006763003}
+        m_MethodName: DoExtract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  receiveValidity:
+    field: {fileID: 0}
+  ruleSource: 0
 --- !u!1001 &1884832341736531406
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -587,12 +876,6 @@ PrefabInstance:
       objectReference: {fileID: 143062437964890755}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 57cea8fee147c654397a0685154f498e, type: 3}
---- !u!4 &785192508888914263 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1210858528001014937, guid: 57cea8fee147c654397a0685154f498e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1884832341736531406}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3185517254728749105 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3899411491897718271, guid: 57cea8fee147c654397a0685154f498e,
@@ -605,6 +888,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6631cbd1a0377e4dafb140bd9df0a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &785192508888914263 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1210858528001014937, guid: 57cea8fee147c654397a0685154f498e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1884832341736531406}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5827561354776127080
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -729,18 +1018,6 @@ PrefabInstance:
       objectReference: {fileID: 785982709505707726}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2006f213367c78b4690c00ea488ad06f, type: 3}
---- !u!114 &4518449307050931127 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7956569273879025119, guid: 2006f213367c78b4690c00ea488ad06f,
-    type: 3}
-  m_PrefabInstance: {fileID: 5827561354776127080}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c18402e6d0a88df479eb7fe789b6f57e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &48161569986075815 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5797455005512497871, guid: 2006f213367c78b4690c00ea488ad06f,
@@ -756,6 +1033,18 @@ MonoBehaviour:
 --- !u!114 &1675643346568561770 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5160769565785776642, guid: 2006f213367c78b4690c00ea488ad06f,
+    type: 3}
+  m_PrefabInstance: {fileID: 5827561354776127080}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c18402e6d0a88df479eb7fe789b6f57e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4518449307050931127 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7956569273879025119, guid: 2006f213367c78b4690c00ea488ad06f,
     type: 3}
   m_PrefabInstance: {fileID: 5827561354776127080}
   m_PrefabAsset: {fileID: 0}
@@ -805,7 +1094,7 @@ PrefabInstance:
     - target: {fileID: 1390912125830776597, guid: bf395407a1df60d4ebaad52cf81795fd,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1390912125830776597, guid: bf395407a1df60d4ebaad52cf81795fd,
         type: 3}
@@ -929,10 +1218,40 @@ PrefabInstance:
       propertyPath: receiveValidity.field
       value: 
       objectReference: {fileID: 6641582858938724152}
+    - target: {fileID: 5255500524047090664, guid: c72a79d4e6496ce4a8d8eff370fb614e,
+        type: 3}
+      propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5255500524047090664, guid: c72a79d4e6496ce4a8d8eff370fb614e,
+        type: 3}
+      propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5255500524047090664, guid: c72a79d4e6496ce4a8d8eff370fb614e,
+        type: 3}
+      propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5255500524047090664, guid: c72a79d4e6496ce4a8d8eff370fb614e,
+        type: 3}
+      propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 8673786206831570023}
+    - target: {fileID: 5255500524047090664, guid: c72a79d4e6496ce4a8d8eff370fb614e,
+        type: 3}
+      propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Receive
+      objectReference: {fileID: 0}
+    - target: {fileID: 5255500524047090664, guid: c72a79d4e6496ce4a8d8eff370fb614e,
+        type: 3}
+      propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 6786077343534509636, guid: c72a79d4e6496ce4a8d8eff370fb614e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6786077343534509636, guid: c72a79d4e6496ce4a8d8eff370fb614e,
         type: 3}
@@ -1019,7 +1338,7 @@ PrefabInstance:
     - target: {fileID: 4152683519229203631, guid: 2a2d88badc746894c98a6a0c451c1b77,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4152683519229203631, guid: 2a2d88badc746894c98a6a0c451c1b77,
         type: 3}


### PR DESCRIPTION
A new path has been added that when an interactable is grabbed, the specific collider on the interactable is emitted to a Rules Matcher so custom logic can be applied before the grab mechanics execute.