### PR TITLE
fix(Interactors): prevent grab on disabled game object

### DIFF
--- a/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
+++ b/Runtime/Interactors/SharedResources/Scripts/GrabInteractorConfigurator.cs
@@ -342,7 +342,7 @@
         /// <param name="ungrabExistingGrab">Whether to ungrab any existing grab.</param>
         public virtual void Grab(InteractableFacade interactable, Collision collision, Collider collider, bool ungrabExistingGrab)
         {
-            if (interactable == null)
+            if (interactable == null || !this.IsValidState())
             {
                 return;
             }


### PR DESCRIPTION
The Grab method on the GrabInteractorConfigurator was able to be run even when the GameObject was disabled, which is not in keeping with Zinnia patterns. This has now been fixed.