### PR TITLE
fix(Grab): prevent infinite loop in grab drop restrictor

### DIFF
--- a/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabDropRestrictor.cs
+++ b/Runtime/Interactables/SharedResources/Scripts/Grab/InteractableGrabDropRestrictor.cs
@@ -40,7 +40,7 @@
         /// <param name="interactable">The Interactable to enable on.</param>
         public virtual void DoEnableDrop(InteractableFacade interactable)
         {
-            DoEnableDrop(interactable);
+            EnableDrop(interactable);
         }
 
         /// <summary>


### PR DESCRIPTION
When calling `DoEnableDrop` it would go into an infinite loop as the main method was being called rather than the sub method.