### PR TITLE
fix(Prefabs): disallow collision consumers for invalid interactor

### DIFF
--- a/Runtime/Interactables/SharedResources/NestedPrefabs/Interactable.GrabReceiver.prefab
+++ b/Runtime/Interactables/SharedResources/NestedPrefabs/Interactable.GrabReceiver.prefab
@@ -1106,6 +1106,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+      - m_Target: {fileID: 5454969332587260584}
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
 --- !u!1 &6786077342896029561
 GameObject:
   m_ObjectHideFlags: 0
@@ -1862,6 +1873,17 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 6786077342379686663}
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5454969332587260584}
         m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:


### PR DESCRIPTION
The DisallowedGrabInteractors rule was causing an issue when using precision grab due to the collision consumer still being published for an invalid interactor which was causing the precision point container to be created for an invalid interactor. This meant that any other valid interactor was not becoming a precision point grab as the detached precision point for the invalid interactor still existed.

The solution is to modify the GrabReceiver prefab so it turns off the OutputActiveCollisionConsumer logic if the interactor is disallowed and then the precision point cannot be created prior to a grab event.